### PR TITLE
[MAINTENANCE] `AlertControl` type error and rank

### DIFF
--- a/src/controls/AlertControl.tsx
+++ b/src/controls/AlertControl.tsx
@@ -1,12 +1,8 @@
+import { LabelProps, RendererProps } from "@jsonforms/core"
 import { Alert } from "antd"
-import { AlertLabelOptions, LabelElement } from "../ui-schema"
+import { AlertLabelOptions } from "../ui-schema"
 
-type AlertControlProps = {
-  text: string
-  uischema: LabelElement
-}
-
-export function AlertControl({ text, uischema }: AlertControlProps) {
-  const options: AlertLabelOptions | undefined = uischema.options
+export function AlertControl({ text, uischema }: LabelProps & RendererProps) {
+  const options = uischema.options as AlertLabelOptions
   return <Alert style={{ marginBottom: "24px" }} type={options?.type} message={text} showIcon />
 }

--- a/src/controls/LabelRendererRegistryEntry.ts
+++ b/src/controls/LabelRendererRegistryEntry.ts
@@ -4,5 +4,5 @@ import { AlertControl } from "./AlertControl"
 
 export const LabelRendererRegistryEntry: JsonFormsRendererRegistryEntry = {
     renderer: withJsonFormsLabelProps(AlertControl),
-    tester: rankWith(100, uiTypeIs("Label")),
+    tester: rankWith(1, uiTypeIs("Label")),
   }


### PR DESCRIPTION
- Fix a typing error that crept in, causing `pnpm pack` to fail
- Revert experimental change to rank