### PR TITLE
fix: add main and types properties to package.json as fallbacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,12 @@
 {
   "name": "@great-expectations/jsonforms-antd-renderers",
   "private": false,
-  "version": "0.1.0",
+  "version": "0.0.0-semantic-release",
   "files": [
     "lib/**/*"
   ],
+  "main": "./lib/cjs/index.js",
+  "types": "./lib/cjs/index.d.ts",
   "exports": {
     "require": {
       "types": "./lib/cjs/index.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
-    "skipLibCheck": false,
+    "skipLibCheck": true,
 
     /* Bundler mode */
     "moduleResolution": "bundler",


### PR DESCRIPTION
Not every project is going to be able to use package.json's `"exports"` property, so I'm adding `"main"` as a fallback