### PR TITLE
chore: Rename options to follow existing pattern

### DIFF
--- a/src/antd/InputNumber.tsx
+++ b/src/antd/InputNumber.tsx
@@ -1,7 +1,7 @@
 import { ReactElement } from "react"
 import { ControlProps, RendererProps } from "@jsonforms/core"
 import { InputNumber as AntdInputNumber } from "antd"
-import { InputNumberOptions } from "../ui-schema"
+import { NumericControlOptions } from "../ui-schema"
 import {
   coerceToInteger,
   coerceToNumber,
@@ -48,7 +48,7 @@ export const InputNumber = (props: InputNumberProps): InputNumber => {
     }
   }
 
-  const options = props.uischema.options as InputNumberOptions
+  const options = props.uischema.options as NumericControlOptions
   const addonAfter = options?.addonAfter
   const addonBefore = options?.addonBefore
   const isPercentage =

--- a/src/layouts/AlertLayout.tsx
+++ b/src/layouts/AlertLayout.tsx
@@ -1,9 +1,9 @@
 import { LabelProps, RendererProps } from "@jsonforms/core"
 import { Alert } from "antd"
-import { AlertLabelOptions } from "../ui-schema"
+import { AlertLayoutOptions } from "../ui-schema"
 
 export function AlertLayout({ text, uischema }: LabelProps & RendererProps) {
-  const options = uischema.options as AlertLabelOptions
+  const options = uischema.options as AlertLayoutOptions
   return (
     <Alert
       style={{ marginBottom: "24px" }}

--- a/src/ui-schema.ts
+++ b/src/ui-schema.ts
@@ -127,10 +127,10 @@ export interface LabelElement extends UISchemaElement, Internationalizable {
   options?: LabelOptions
 }
 
-export type AlertLabelOptions = { type: AlertProps["type"] }
+export type AlertLayoutOptions = { type: AlertProps["type"] }
 
 // this is intended to be a union, it just has one member rn
-export type LabelOptions = AlertLabelOptions
+export type LabelOptions = AlertLayoutOptions
 
 export const OneOfControlOptions = [
   "button",
@@ -283,7 +283,7 @@ type AndCondition = ComposableCondition & {
   type: "AND"
 }
 
-export type InputNumberOptions = {
+export type NumericControlOptions = {
   addonBefore?: InputNumberProps["addonBefore"]
   addonAfter?: InputNumberProps["addonAfter"]
 }


### PR DESCRIPTION
- Rename `AlertLabelOptions` -> `AlertLayoutOptions`
- Rename `InputNumberOptions` -> `NumericControlOptions`