### PR TITLE
feat(UISchema): typecheck UISchema scope values against jsonschema property paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@ function MyForm() {
 
 ### Writing UISchemas
 
-This package expands upon the types and configurability of [jsonforms UISchemas](https://jsonforms.io/docs/uischema). When writing UISchemas, you'll want to
-import our UISchema types (like `TextControlOptions` below) to take advantage of our configurability. See our storybooks (instructions for running storybooks under `Contributing`) for more examples.
+This package expands upon the types and configurability of [jsonforms UISchemas](https://jsonforms.io/docs/uischema). When writing UISchemas, you'll want to provide your jsonschema's type to our `UISchema` type to take advantage of advanced typechecking & UI configurability. See our storybooks (instructions for running storybooks under `Contributing`) for more examples.
 
 ```tsx
 import { JsonForms } from "@jsonforms/react"
@@ -58,7 +57,7 @@ const schema = {
   properties: { password: { type: "string" } },
 }
 
-const uischema = {
+const uischema: UISchema<typeof schema> = {
   type: "VerticalLayout",
   elements: [
     {
@@ -66,7 +65,7 @@ const uischema = {
       scope: "#/properties/password",
       // properties like type: "password" here are unique to this renderer package. This allows you more declarative control over how your forms
       // render. In this case, the password field will be rendered with AntD's password input component
-      options: { type: "password" } satisfies TextControlOptions,
+      options: { type: "password" },
     },
   ],
 }

--- a/src/common/AntDJsonForm.tsx
+++ b/src/common/AntDJsonForm.tsx
@@ -10,18 +10,18 @@ import {
   cellRegistryEntries,
 } from "../renderer-registry-entries"
 
-type Props = {
+type Props<T> = {
   data: Record<string, unknown>
   updateData: (data: Record<string, unknown>) => void
-  jsonSchema: JsonSchema7
-  uiSchema?: UISchema
+  jsonSchema: T
+  uiSchema?: UISchema<T>
   uiSchemaRegistryEntries?: JsonFormsUISchemaRegistryEntry[]
   customRendererRegistryEntries?: JsonFormsRendererRegistryEntry[]
   rendererRegistryEntries?: JsonFormsRendererRegistryEntry[]
   config?: Record<string, unknown>
 }
 
-export function AntDJsonForm({
+export function AntDJsonForm<T = Record<string, unknown>>({
   uiSchema,
   jsonSchema,
   data,
@@ -30,10 +30,10 @@ export function AntDJsonForm({
   customRendererRegistryEntries,
   rendererRegistryEntries = _rendererRegistryEntries,
   config,
-}: Props) {
+}: Props<T>) {
   return (
     <JsonForms
-      schema={jsonSchema}
+      schema={jsonSchema as JsonSchema7}
       uischema={uiSchema}
       uischemas={uiSchemaRegistryEntries ?? []}
       data={data}

--- a/src/common/ControlLabel.test.tsx
+++ b/src/common/ControlLabel.test.tsx
@@ -28,7 +28,7 @@ describe("ControlLabel", () => {
             label: "No, Label ME",
           },
         ],
-      } satisfies UISchema,
+      } satisfies UISchema<typeof schema>,
     })
     await screen.findByText("No, Label ME")
   })
@@ -46,7 +46,7 @@ describe("ControlLabel", () => {
             },
           },
         ],
-      } satisfies UISchema,
+      } satisfies UISchema<typeof schema>,
     })
     await screen.findByText("Srsly, label me instead")
   })
@@ -66,7 +66,7 @@ describe("ControlLabel", () => {
             },
           },
         ],
-      } satisfies UISchema,
+      } satisfies UISchema<typeof schema>,
     })
     await screen.findByText("Srsly, label me instead")
 
@@ -90,7 +90,7 @@ describe("ControlLabel", () => {
             },
           },
         ],
-      } satisfies UISchema,
+      } satisfies UISchema<typeof schema>,
     })
     await screen.findByLabelText("copy")
   })

--- a/src/common/ControlLabel.tsx
+++ b/src/common/ControlLabel.tsx
@@ -1,5 +1,5 @@
-import { JsonSchema, Helpers } from "@jsonforms/core"
-import { ControlUISchema } from "../ui-schema"
+import { JsonSchema, Helpers, ControlElement } from "@jsonforms/core"
+import { ControlUISchema, ControlUISchemaLabel } from "../ui-schema"
 import { Typography } from "antd"
 import { assertNever } from "./assert-never"
 
@@ -8,29 +8,31 @@ export function ControlLabel({
   uischema,
   schema,
 }: {
-  uischema: ControlUISchema
+  uischema: ControlUISchema<unknown>
   schema: JsonSchema
 }) {
-  const controlUISchema: ControlUISchema = uischema
-  const labelDescription = Helpers.createLabelDescriptionFrom(uischema, schema)
+  const labelDescription = Helpers.createLabelDescriptionFrom(
+    uischema as unknown as ControlElement,
+    schema,
+  )
   const text = labelDescription.show ? labelDescription.text : null
-
+  const labeledUISchema = uischema as ControlUISchemaLabel
   if (
-    typeof controlUISchema.label === "object" &&
-    "type" in controlUISchema.label
+    typeof labeledUISchema.label === "object" &&
+    "type" in labeledUISchema.label
   ) {
-    const labelType = controlUISchema.label.type
+    const labelType = labeledUISchema.label.type
     switch (labelType) {
       case "Text":
         return (
-          <Typography.Text {...controlUISchema.label.textProps}>
+          <Typography.Text {...labeledUISchema.label.textProps}>
             {text}
           </Typography.Text>
         )
 
       case "Title":
         return (
-          <Typography.Title {...controlUISchema.label.titleProps}>
+          <Typography.Title {...labeledUISchema.label.titleProps}>
             {text}
           </Typography.Title>
         )

--- a/src/common/FormStateWrapper.tsx
+++ b/src/common/FormStateWrapper.tsx
@@ -1,5 +1,4 @@
 import { JsonForms } from "@jsonforms/react"
-import { JSONSchema } from "json-schema-to-ts"
 import { Form } from "antd"
 
 import { JsonSchema7 } from "@jsonforms/core"
@@ -10,19 +9,19 @@ import {
 } from "../renderer-registry-entries"
 import { useState } from "react"
 
-type RenderProps<T extends Record<string, unknown>> = {
-  schema: JSONSchema
+type RenderProps<T extends Record<string, unknown>, S> = {
+  schema: S
   data?: T
-  uischema?: UISchema
+  uischema?: UISchema<S>
   onChange?: (result: { data: T }) => void
 }
 
-export function FormStateWrapper<T extends Record<string, unknown>>({
+export function FormStateWrapper<T extends Record<string, unknown>, S>({
   schema,
   uischema,
   data: initialData,
   onChange,
-}: RenderProps<T>) {
+}: RenderProps<T, S>) {
   const [data, setData] = useState<Record<string, unknown> | undefined>(
     initialData,
   )

--- a/src/common/StorybookAntDJsonForm.tsx
+++ b/src/common/StorybookAntDJsonForm.tsx
@@ -1,25 +1,23 @@
 import {
   JsonFormsRendererRegistryEntry,
   JsonFormsUISchemaRegistryEntry,
-  JsonSchema7,
 } from "@jsonforms/core"
 import { UISchema } from "../ui-schema"
 import { AntDJsonForm } from "./AntDJsonForm"
 import { useState } from "react"
-import { JSONSchema } from "json-schema-to-ts"
 
-type Props = {
+type Props<T> = {
   data?: Record<string, unknown>
-  jsonSchema: JSONSchema
+  jsonSchema: T
   rendererRegistryEntries: JsonFormsRendererRegistryEntry[]
-  uiSchema?: UISchema
+  uiSchema?: UISchema<T>
   uiSchemaRegistryEntries?: JsonFormsUISchemaRegistryEntry[]
   config?: Record<string, unknown>
   onChange: (data: Record<string, unknown>) => void
 }
 
 // this component exists to facilitate storybook rendering
-export function StorybookAntDJsonForm({
+export function StorybookAntDJsonForm<T>({
   data: initialData = {},
   uiSchema,
   jsonSchema,
@@ -27,16 +25,16 @@ export function StorybookAntDJsonForm({
   rendererRegistryEntries,
   config,
   onChange,
-}: Props) {
+}: Props<T>) {
   const [data, setData] = useState(initialData)
   const updateData = (newData: Record<string, unknown>) => {
     setData(newData)
     onChange(newData)
   }
   return (
-    <AntDJsonForm
+    <AntDJsonForm<typeof jsonSchema>
       uiSchema={uiSchema}
-      jsonSchema={jsonSchema as JsonSchema7}
+      jsonSchema={jsonSchema}
       data={data}
       updateData={(newData) => updateData(newData)}
       uiSchemaRegistryEntries={uiSchemaRegistryEntries}

--- a/src/common/schema-derived-types.ts
+++ b/src/common/schema-derived-types.ts
@@ -5,6 +5,7 @@ import {
   NumericControlOptions,
   OneOfControlOptions,
   TextControlOptions,
+  UISchema,
 } from ".."
 
 export type JSONFormData<T extends JSONSchema> = RecursivePartial<FromSchema<T>>
@@ -90,7 +91,8 @@ export const ObjectUISchema3: SchemaAwareScope<typeof objectSchema> = {
   scope: "#/properties/person/properties/name",
 }
 
-export const OneOfUISchema: SchemaAwareScope<typeof oneOfSchema> = {
+export const OneOfUISchema: UISchema<typeof oneOfSchema> = {
+  type: "Control",
   scope: "#/properties/person",
   options: { optionType: "button" },
 }

--- a/src/common/schema-derived-types.ts
+++ b/src/common/schema-derived-types.ts
@@ -6,3 +6,11 @@ export type JSONData<T extends JSONSchema> = FromSchema<T>
 type RecursivePartial<T> = T extends object
   ? { [K in keyof T]?: RecursivePartial<T[K]> }
   : T
+
+type _Paths<T extends object> = {
+  [K in keyof T & (string | number)]: T[K] extends object
+    ? `${K}` | `${K}/${_Paths<T[K]>}`
+    : `${K}`
+}[keyof T & (string | number)]
+
+export type Paths<T extends object> = `#/${_Paths<T>}`

--- a/src/common/schema-derived-types.ts
+++ b/src/common/schema-derived-types.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { FromSchema, JSONSchema } from "json-schema-to-ts"
 import {
   AnyOfControlOptions,
@@ -31,8 +30,6 @@ type JsonSchemaTypeToControlOptions<
     : T[K] extends { oneOf: unknown }
       ? OneOfControlOptions
       : unknown
-
-let s: SchemaAwareScope<unknown>
 
 // This is a type called SchemaAwareScope that takes up to two type arguments
 export type SchemaAwareScope<T = unknown> = T extends object

--- a/src/common/schema-derived-types.ts
+++ b/src/common/schema-derived-types.ts
@@ -15,17 +15,88 @@ type RecursivePartial<T> = T extends object
   ? { [K in keyof T]?: RecursivePartial<T[K]> }
   : T
 
-type _Paths<T extends object> = {
-  [K in keyof T & (string | number)]: T[K] extends object
-    ? `${K}` | `${K}/${_Paths<T[K]>}`
-    : `${K}`
-}[keyof T & (string | number)]
+type JsonSchemaTypeToControlOptions<
+  T,
+  K extends keyof T & string,
+> = T[K] extends { type: infer U }
+  ? U extends "string"
+    ? TextControlOptions
+    : U extends "number" | "integer"
+      ? NumericControlOptions
+      : U extends "array"
+        ? ArrayControlOptions
+        : unknown
+  : T[K] extends { anyOf: unknown }
+    ? AnyOfControlOptions
+    : T[K] extends { oneOf: unknown }
+      ? OneOfControlOptions
+      : unknown
 
-export type Paths<T extends object> = `#/${_Paths<T>}`
+let s: SchemaAwareScope<unknown>
 
-type AllPaths = _Paths<typeof objectSchema>
+// This is a type called SchemaAwareScope that takes up to two type arguments
+export type SchemaAwareScope<T = unknown> = T extends object
+  ? _SchemaAwareScope<T>
+  : { scope: string; [key: string]: unknown }
 
-type UnwrapPath<T> = T extends `#/${infer U}` ? U : T
+type _SchemaAwareScope<T, Prefix extends string = ""> = {
+  // let's define properties for each key in object type T
+  [K in keyof T & string]: T[K] extends  // is this a property we can apply a control to?
+    | { type: string }
+    | { anyOf: unknown }
+    | { oneOf: unknown }
+    ? // we can apply a control to it
+      // does it have a typed options property? if this type extends object, that means T[K] is a property that has typed options, e.g. TextControlOptions
+      JsonSchemaTypeToControlOptions<T, K> extends object
+      ? // it does have a typed options property, so we provide that type info
+        {
+          // it does have a typed options property, so this is the type
+          scope: Prefix extends "" ? `#/${K}` : `${Prefix}/${K}`
+          options?: JsonSchemaTypeToControlOptions<T, K>
+        }
+      : // it doesn't have a typed options property
+        // does it have properties of its own?
+        T[K] extends { properties: unknown }
+        ? // it does have properties of its own; let's union our type with a recursive call to SchemaAwareScope
+          | {
+                scope: Prefix extends "" ? `#/${K}` : `${Prefix}/${K}`
+              }
+            | _SchemaAwareScope<
+                T[K],
+                Prefix extends "" ? `#/${K}` : `${Prefix}/${K}`
+              >
+        : // it doesn't have properties of its own, let's provide the type:
+          {
+            scope: Prefix extends "" ? `#/${K}` : `${Prefix}/${K}`
+          }
+    : K extends "properties" // is our key the "properties" key?
+      ? // it is, so make a recursive call for all the properties
+        _SchemaAwareScope<T[K], Prefix extends "" ? `#/${K}` : `${Prefix}/${K}`>
+      : // it isn't, so let's exclude this path and property from our type
+        never
+}[keyof T & string] // make this type a union of the properties of the object type we created
+
+export const ObjectUISchema: SchemaAwareScope<typeof objectSchema> = {
+  scope: "#/properties/person",
+}
+export const ObjectUISchema1: SchemaAwareScope<typeof objectSchema> = {
+  // @ts-expect-error this object is a test to ensure that "properties" is an invalid value for scope
+  scope: "properties",
+}
+
+export const ObjectUISchema2: SchemaAwareScope<typeof objectSchema> = {
+  scope: "#/properties/person/properties/name",
+  options: { rules: [] },
+}
+
+export const ObjectUISchema3: SchemaAwareScope<typeof objectSchema> = {
+  scope: "#/properties/person/properties/name",
+}
+
+export const OneOfUISchema: SchemaAwareScope<typeof oneOfSchema> = {
+  scope: "#/properties/person",
+  options: { optionType: "button" },
+}
 
 export const objectSchema = {
   type: "object",
@@ -58,75 +129,3 @@ export const oneOfSchema = {
     },
   },
 } satisfies JSONSchema
-
-type JsonSchemaTypeToControlOptions<
-  T,
-  K extends keyof T & string,
-> = T[K] extends { type: infer U }
-  ? U extends "string"
-    ? TextControlOptions
-    : U extends "number" | "integer"
-      ? NumericControlOptions
-      : U extends "array"
-        ? ArrayControlOptions
-        : unknown
-  : T[K] extends { anyOf: unknown }
-    ? AnyOfControlOptions
-    : T[K] extends { oneOf: unknown }
-      ? OneOfControlOptions
-      : unknown
-
-type NewUISchema<T, Prefix extends string = ""> = {
-  // let's define properties for each key in object type T
-  [K in keyof T & string]: T[K] extends  // is this a property we can apply a control to?
-    | { type: string }
-    | { anyOf: unknown }
-    | { oneOf: unknown }
-    ? // we can apply a control to it
-      // does it have a typed options property? if this type extends object, that means T[K] is a property that has typed options, e.g. TextControlOptions
-      JsonSchemaTypeToControlOptions<T, K> extends object
-      ? // it does have a typed options property, so we provide that type info
-        {
-          // it does have a typed options property, so this is the type
-          scope: Prefix extends "" ? `${K}` : `${Prefix}/${K}`
-          options?: JsonSchemaTypeToControlOptions<T, K>
-        }
-      : // it doesn't have a typed options property
-        // does it have properties of its own?
-        T[K] extends { properties: unknown }
-        ? // it does have properties of its own; let's union our type with a recursive call to NewUISchema
-          | {
-                scope: Prefix extends "" ? `${K}` : `${Prefix}/${K}`
-              }
-            | NewUISchema<T[K], Prefix extends "" ? `${K}` : `${Prefix}/${K}`>
-        : // it doesn't have properties of its own, let's provide the type:
-          {
-            scope: Prefix extends "" ? `${K}` : `${Prefix}/${K}`
-          }
-    : K extends "properties" // is our key the "properties" key?
-      ? // it is, so make a recursive call for all the properties
-        NewUISchema<T[K], Prefix extends "" ? `${K}` : `${Prefix}/${K}`>
-      : // it isn't, so let's exclude this path and property from our type
-        never
-}[keyof T & string] // make this type a union of the properties of the object type we created
-
-const ObjectUISchema: NewUISchema<typeof objectSchema> = {
-  scope: "properties/person",
-}
-const ObjectUISchema1: NewUISchema<typeof objectSchema> = {
-  scope: "properties",
-}
-
-const ObjectUISchema2: NewUISchema<typeof objectSchema> = {
-  scope: "properties/person/properties/name",
-  options: { rules: [] },
-}
-
-const ObjectUISchema3: NewUISchema<typeof objectSchema> = {
-  scope: "properties/person/properties/name",
-}
-
-const OneOfUISchema: NewUISchema<typeof oneOfSchema> = {
-  scope: "properties/person",
-  options: { optionType: "button" },
-}

--- a/src/common/schema-derived-types.ts
+++ b/src/common/schema-derived-types.ts
@@ -1,4 +1,12 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { FromSchema, JSONSchema } from "json-schema-to-ts"
+import {
+  AnyOfControlOptions,
+  ArrayControlOptions,
+  NumericControlOptions,
+  OneOfControlOptions,
+  TextControlOptions,
+} from ".."
 
 export type JSONFormData<T extends JSONSchema> = RecursivePartial<FromSchema<T>>
 export type JSONData<T extends JSONSchema> = FromSchema<T>
@@ -14,3 +22,111 @@ type _Paths<T extends object> = {
 }[keyof T & (string | number)]
 
 export type Paths<T extends object> = `#/${_Paths<T>}`
+
+type AllPaths = _Paths<typeof objectSchema>
+
+type UnwrapPath<T> = T extends `#/${infer U}` ? U : T
+
+export const objectSchema = {
+  type: "object",
+  properties: {
+    person: {
+      type: "object",
+      properties: {
+        name: {
+          type: "string",
+        },
+      },
+    },
+  },
+} satisfies JSONSchema
+
+export const oneOfSchema = {
+  type: "object",
+  properties: {
+    person: {
+      oneOf: [
+        {
+          type: "object",
+          properties: {
+            name: {
+              type: "string",
+            },
+          },
+        },
+      ],
+    },
+  },
+} satisfies JSONSchema
+
+type JsonSchemaTypeToControlOptions<
+  T,
+  K extends keyof T & string,
+> = T[K] extends { type: infer U }
+  ? U extends "string"
+    ? TextControlOptions
+    : U extends "number" | "integer"
+      ? NumericControlOptions
+      : U extends "array"
+        ? ArrayControlOptions
+        : unknown
+  : T[K] extends { anyOf: unknown }
+    ? AnyOfControlOptions
+    : T[K] extends { oneOf: unknown }
+      ? OneOfControlOptions
+      : unknown
+
+type NewUISchema<T, Prefix extends string = ""> = {
+  // let's define properties for each key in object type T
+  [K in keyof T & string]: T[K] extends  // is this a property we can apply a control to?
+    | { type: string }
+    | { anyOf: unknown }
+    | { oneOf: unknown }
+    ? // we can apply a control to it
+      // does it have a typed options property? if this type extends object, that means T[K] is a property that has typed options, e.g. TextControlOptions
+      JsonSchemaTypeToControlOptions<T, K> extends object
+      ? // it does have a typed options property, so we provide that type info
+        {
+          // it does have a typed options property, so this is the type
+          scope: Prefix extends "" ? `${K}` : `${Prefix}/${K}`
+          options?: JsonSchemaTypeToControlOptions<T, K>
+        }
+      : // it doesn't have a typed options property
+        // does it have properties of its own?
+        T[K] extends { properties: unknown }
+        ? // it does have properties of its own; let's union our type with a recursive call to NewUISchema
+          | {
+                scope: Prefix extends "" ? `${K}` : `${Prefix}/${K}`
+              }
+            | NewUISchema<T[K], Prefix extends "" ? `${K}` : `${Prefix}/${K}`>
+        : // it doesn't have properties of its own, let's provide the type:
+          {
+            scope: Prefix extends "" ? `${K}` : `${Prefix}/${K}`
+          }
+    : K extends "properties" // is our key the "properties" key?
+      ? // it is, so make a recursive call for all the properties
+        NewUISchema<T[K], Prefix extends "" ? `${K}` : `${Prefix}/${K}`>
+      : // it isn't, so let's exclude this path and property from our type
+        never
+}[keyof T & string] // make this type a union of the properties of the object type we created
+
+const ObjectUISchema: NewUISchema<typeof objectSchema> = {
+  scope: "properties/person",
+}
+const ObjectUISchema1: NewUISchema<typeof objectSchema> = {
+  scope: "properties",
+}
+
+const ObjectUISchema2: NewUISchema<typeof objectSchema> = {
+  scope: "properties/person/properties/name",
+  options: { rules: [] },
+}
+
+const ObjectUISchema3: NewUISchema<typeof objectSchema> = {
+  scope: "properties/person/properties/name",
+}
+
+const OneOfUISchema: NewUISchema<typeof oneOfSchema> = {
+  scope: "properties/person",
+  options: { optionType: "button" },
+}

--- a/src/common/test-render.tsx
+++ b/src/common/test-render.tsx
@@ -1,18 +1,17 @@
 import { render as RTLrender } from "@testing-library/react"
-import { JSONSchema } from "json-schema-to-ts"
 
 import { UISchema } from "../ui-schema"
 import { FormStateWrapper } from "./FormStateWrapper"
 
-type RenderProps<T extends Record<string, unknown>> = {
-  schema: JSONSchema
+type RenderProps<T extends Record<string, unknown>, S> = {
+  schema: S
   data?: T
-  uischema?: UISchema
+  uischema?: UISchema<S>
   onChange?: (result: { data: T }) => void
 }
 
-export function render<T extends Record<string, unknown>>(
-  props: RenderProps<T>,
+export function render<T extends Record<string, unknown>, S>(
+  props: RenderProps<T, S>,
 ) {
   return RTLrender(<FormStateWrapper {...props} />)
 }

--- a/src/controls/TextControl.test.tsx
+++ b/src/controls/TextControl.test.tsx
@@ -72,11 +72,11 @@ test("updates jsonforms data as expected", async () => {
 })
 
 test("renders a password when present", async () => {
-  const passwordUISchema: UISchema = {
+  const passwordUISchema = {
     type: "Control",
     scope: "#/properties/secret",
     options: { type: "password" },
-  }
+  } satisfies UISchema<typeof passwordSchema>
   const passwordSchema = {
     properties: { secret: { type: "string", title: "Secret" } },
   } satisfies JSONSchema
@@ -92,18 +92,18 @@ test("renders a password when present", async () => {
 })
 
 test("renders error messages from rule validation", async () => {
-  const patternUISchema: UISchema = {
+  const patternUISchema = {
     type: "Control",
     scope: "#/properties/name",
     options: {
       rules: [
         {
-          pattern: "^[a-zA-Z ]*$",
+          pattern: /^[a-zA-Z ]*$/,
           message: "Only letters are allowed",
         },
       ],
     },
-  }
+  } satisfies UISchema<typeof patternSchema>
 
   const patternSchema = {
     type: "object",

--- a/src/controls/combinators/AnyOfControl.test.tsx
+++ b/src/controls/combinators/AnyOfControl.test.tsx
@@ -2,12 +2,30 @@ import { screen } from "@testing-library/react"
 import { test, expect, describe } from "vitest"
 import { render } from "../../common/test-render"
 import userEvent from "@testing-library/user-event"
-import { AnyOfControlOptions } from "../../ui-schema"
 
 import {
   SplitterUISchemaRegistryEntry,
   splitterAnyOfJsonSchema,
 } from "../../testSchemas/anyOfSchema"
+import { UISchema } from "../../ui-schema"
+
+const uischema: UISchema<typeof splitterAnyOfJsonSchema> = {
+  type: "VerticalLayout",
+  elements: [
+    {
+      type: "Control",
+      scope: "#/properties/splitter",
+      options: {
+        optionType: "button",
+        subschemaTitleToLabelMap: {
+          SplitterYear: "Year",
+          SplitterYearAndMonthAndDay: "Year - Month - Day",
+          SplitterYearAndMonth: "Year - Month",
+        },
+      },
+    },
+  ],
+}
 
 describe("AnyOf control", () => {
   test("AnyOf Control with default (radio) UISchema allows switching between subschemas", async () => {
@@ -19,7 +37,7 @@ describe("AnyOf control", () => {
 
     // UiSchema is not set here, so we should see the Method Name changing
 
-    await userEvent.click(screen.getByLabelText("Year - Month"))
+    await userEvent.click(screen.getByLabelText("SplitterYearAndMonth"))
     screen.getByLabelText("Column Name")
     expect(screen.queryByLabelText("Method Name")).toHaveValue(
       "split_on_year_and_month",
@@ -28,16 +46,7 @@ describe("AnyOf control", () => {
   test("AnyOf Control with button UISchema allows switching between subschemas and respects uiSchemaRegistryEntries", async () => {
     render({
       schema: splitterAnyOfJsonSchema,
-      uischema: {
-        type: "VerticalLayout",
-        elements: [
-          {
-            type: "Control",
-            scope: "#/properties/splitter",
-            options: { optionType: "button" } satisfies AnyOfControlOptions,
-          },
-        ],
-      },
+      uischema,
       uiSchemaRegistryEntries: [SplitterUISchemaRegistryEntry],
     })
     // Column Name is available in both subschemas
@@ -57,16 +66,7 @@ describe("AnyOf control", () => {
   test("AnyOf Control with dropdown UISchema allows switching between subschemas", async () => {
     render({
       schema: splitterAnyOfJsonSchema,
-      uischema: {
-        type: "VerticalLayout",
-        elements: [
-          {
-            type: "Control",
-            scope: "#/properties/splitter",
-            options: { optionType: "dropdown" } satisfies AnyOfControlOptions,
-          },
-        ],
-      },
+      uischema,
     })
     // Column Name is available in both subschemas
     await screen.findByText("Splitter")
@@ -91,12 +91,12 @@ describe("AnyOf control", () => {
     screen.getByLabelText("Column Name")
     await userEvent.type(screen.getByLabelText("Column Name"), "abc")
 
-    await userEvent.click(screen.getByLabelText("Year - Month"))
+    await userEvent.click(screen.getByLabelText("SplitterYearAndMonth"))
     screen.getByLabelText("Column Name")
     expect(screen.queryByLabelText("Column Name")).not.toHaveValue("abc")
     await userEvent.type(screen.getByLabelText("Column Name"), "xyz")
 
-    await userEvent.click(screen.getByLabelText("Year"))
+    await userEvent.click(screen.getByLabelText("SplitterYear"))
     screen.getByLabelText("Column Name")
     expect(screen.queryByLabelText("Column Name")).toHaveValue("abc")
   })

--- a/src/controls/combinators/AnyOfControl.test.tsx
+++ b/src/controls/combinators/AnyOfControl.test.tsx
@@ -6,12 +6,12 @@ import { AnyOfControlOptions } from "../../ui-schema"
 
 import {
   SplitterUISchemaRegistryEntry,
-  anyOfJsonSchema,
+  splitterAnyOfJsonSchema,
 } from "../../testSchemas/anyOfSchema"
 
 describe("AnyOf control", () => {
   test("AnyOf Control with default (radio) UISchema allows switching between subschemas", async () => {
-    render({ schema: anyOfJsonSchema })
+    render({ schema: splitterAnyOfJsonSchema })
     // Column Name is available in both subschemas
     await screen.findByText("Splitter")
     screen.getByLabelText("Column Name")
@@ -27,7 +27,7 @@ describe("AnyOf control", () => {
   })
   test("AnyOf Control with button UISchema allows switching between subschemas and respects uiSchemaRegistryEntries", async () => {
     render({
-      schema: anyOfJsonSchema,
+      schema: splitterAnyOfJsonSchema,
       uischema: {
         type: "VerticalLayout",
         elements: [
@@ -56,7 +56,7 @@ describe("AnyOf control", () => {
   })
   test("AnyOf Control with dropdown UISchema allows switching between subschemas", async () => {
     render({
-      schema: anyOfJsonSchema,
+      schema: splitterAnyOfJsonSchema,
       uischema: {
         type: "VerticalLayout",
         elements: [
@@ -84,7 +84,7 @@ describe("AnyOf control", () => {
     )
   })
   test("AnyOf Control persists state when switching between subschemas", async () => {
-    render({ schema: anyOfJsonSchema })
+    render({ schema: splitterAnyOfJsonSchema })
 
     // Column Name is available in both subschemas
     await screen.findByText("Splitter")

--- a/src/controls/combinators/CombinatorSchemaSwitcher.tsx
+++ b/src/controls/combinators/CombinatorSchemaSwitcher.tsx
@@ -36,6 +36,7 @@ export function CombinatorSchemaSwitcher({
     uischema.options as Record<string, unknown>,
   ) as OneOfControlOptions
   const oneOfOptionType = appliedUiSchemaOptions.optionType
+  const labelMap = appliedUiSchemaOptions.subschemaTitleToLabelMap
   const prevSelectedIndex = usePreviousValue(selectedIndex)
   const [dataForPreviousSchemas, setDataForPreviousSchemas] = useState<
     Record<number, unknown>
@@ -74,7 +75,7 @@ export function CombinatorSchemaSwitcher({
   ])
 
   const options = renderInfos.map((renderInfo, index) => ({
-    label: renderInfo.label,
+    label: labelMap?.[renderInfo.label] ?? renderInfo.label,
     value: index,
   }))
 

--- a/src/controls/combinators/OneOfControl.tsx
+++ b/src/controls/combinators/OneOfControl.tsx
@@ -39,7 +39,10 @@ export function OneOfControl({
     <Space direction="vertical" style={{ width: "100%" }} size="middle">
       {uischema.type === "Control" && ( // I don't think it's possible for this to be false
         // but until we improve the UISchema types a bit, it's hard to be sure
-        <ControlLabel uischema={uischema as ControlUISchema} schema={schema} />
+        <ControlLabel
+          uischema={uischema as ControlUISchema<unknown>}
+          schema={schema}
+        />
       )}
       <CombinatorSchemaSwitcher
         config={config as unknown}

--- a/src/layouts/AlertLayout.test.tsx
+++ b/src/layouts/AlertLayout.test.tsx
@@ -27,7 +27,6 @@ test("AlertLayout renders", async () => {
         {
           type: "Label",
           text: "An African swallow, maybe -- but not a European swallow, that's my point.",
-          options: {},
         },
       ],
     },

--- a/src/layouts/GroupLayout.tsx
+++ b/src/layouts/GroupLayout.tsx
@@ -6,7 +6,7 @@ import React from "react"
 import { assertNever } from "../common/assert-never"
 
 export type LayoutRendererProps = OwnPropsOfRenderer & {
-  elements: UISchema[]
+  elements: UISchema<unknown>[]
 }
 
 export function GroupLayout({
@@ -15,7 +15,7 @@ export function GroupLayout({
   uischema,
   ...props
 }: LayoutRendererProps) {
-  const groupLayout = uischema as GroupLayoutUISchema
+  const groupLayout = uischema as GroupLayoutUISchema<unknown>
   if ("groupType" in groupLayout) {
     const type = groupLayout.groupType
     switch (type) {

--- a/src/layouts/HorizontalLayout.tsx
+++ b/src/layouts/HorizontalLayout.tsx
@@ -14,7 +14,7 @@ export function HorizontalLayout({
   renderers,
   cells,
 }: LayoutProps) {
-  const horizontalLayout = uischema as HorizontalLayoutUISchema
+  const horizontalLayout = uischema as HorizontalLayoutUISchema<unknown>
   const groupLayout = uischema as GroupLayout
   const childProps: AntDLayoutProps = {
     elements: horizontalLayout.elements,

--- a/src/layouts/LayoutRenderer.tsx
+++ b/src/layouts/LayoutRenderer.tsx
@@ -4,7 +4,7 @@ import { renderLayoutElements } from "./render-layout-elements"
 import { UISchema } from "../ui-schema"
 
 export interface AntDLayoutProps extends OwnPropsOfRenderer {
-  elements: UISchema[]
+  elements: UISchema<unknown>[]
   direction?: "row" | "column"
 }
 

--- a/src/layouts/VerticalLayout.tsx
+++ b/src/layouts/VerticalLayout.tsx
@@ -13,7 +13,7 @@ export function VerticalLayout({
   renderers,
   cells,
 }: LayoutProps) {
-  const verticalLayout = uischema as VerticalLayoutUISchema
+  const verticalLayout = uischema as VerticalLayoutUISchema<unknown>
   const groupLayout = uischema as GroupLayout
   const childProps: AntDLayoutProps = {
     elements: verticalLayout.elements,

--- a/src/stories/controls/AnyOfControl.stories.tsx
+++ b/src/stories/controls/AnyOfControl.stories.tsx
@@ -1,57 +1,57 @@
 import { Meta, StoryObj } from "@storybook/react"
 import { rendererRegistryEntries } from "../../renderer-registry-entries"
-import { OneOfControlOptions, UISchema } from "../../ui-schema"
 import { StorybookAntDJsonForm } from "../../common/StorybookAntDJsonForm"
 import {
   SplitterUISchemaRegistryEntry,
-  anyOfJsonSchema,
+  splitterAnyOfJsonSchema,
 } from "../../testSchemas/anyOfSchema"
 
-const meta: Meta<typeof StorybookAntDJsonForm> = {
-  title: "Control/AnyOf",
-  component: StorybookAntDJsonForm,
-  parameters: {
-    // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/configure/story-layout
-    layout: "centered",
-  },
-  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
-  tags: ["autodocs"],
-  args: {
-    jsonSchema: anyOfJsonSchema,
-    uiSchema: {
-      type: "VerticalLayout",
-      elements: [
-        {
-          type: "Control",
-          scope: "#/properties/splitter",
-        },
-      ],
-    } satisfies UISchema,
-    rendererRegistryEntries: [...rendererRegistryEntries],
-    uiSchemaRegistryEntries: [SplitterUISchemaRegistryEntry],
-  },
-  // More on argTypes: https://storybook.js.org/docs/api/argtypes
-  argTypes: {
-    rendererRegistryEntries: { table: { disable: true } },
-    jsonSchema: {
-      control: "object",
-      description: "this is a minimal anyOf combinator schema",
+const meta: Meta<typeof StorybookAntDJsonForm<typeof splitterAnyOfJsonSchema>> =
+  {
+    title: "Control/AnyOf",
+    component: StorybookAntDJsonForm,
+    parameters: {
+      // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/configure/story-layout
+      layout: "centered",
     },
-    uiSchemaRegistryEntries: { table: { disable: true } },
-    data: { table: { disable: true } },
-    config: { control: "object" },
-    onChange: { table: { disable: true, action: "on-change" } },
-  },
-}
+    // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
+    tags: ["autodocs"],
+    args: {
+      jsonSchema: splitterAnyOfJsonSchema,
+      uiSchema: {
+        type: "VerticalLayout",
+        elements: [
+          {
+            type: "Control",
+            scope: "#/properties/splitter",
+          },
+        ],
+      },
+      rendererRegistryEntries: [...rendererRegistryEntries],
+      uiSchemaRegistryEntries: [SplitterUISchemaRegistryEntry],
+    },
+    // More on argTypes: https://storybook.js.org/docs/api/argtypes
+    argTypes: {
+      rendererRegistryEntries: { table: { disable: true } },
+      jsonSchema: {
+        control: "object",
+        description: "this is a minimal anyOf combinator schema",
+      },
+      uiSchemaRegistryEntries: { table: { disable: true } },
+      data: { table: { disable: true } },
+      config: { control: "object" },
+      onChange: { table: { disable: true, action: "on-change" } },
+    },
+  }
 
 export default meta
-type Story = StoryObj<typeof StorybookAntDJsonForm>
+type Story<T> = StoryObj<typeof StorybookAntDJsonForm<T>>
 
-export const RadioGroup: Story = {
+export const RadioGroup: Story<typeof splitterAnyOfJsonSchema> = {
   parameters: { controls: { expanded: true } },
   tags: ["autodocs"],
   args: {
-    jsonSchema: anyOfJsonSchema,
+    jsonSchema: splitterAnyOfJsonSchema,
     uiSchema: {
       type: "VerticalLayout",
       elements: [{ type: "Control", scope: "#/properties/splitter" }],
@@ -65,18 +65,18 @@ export const RadioGroup: Story = {
   },
 }
 
-export const Button: Story = {
+export const Button: Story<typeof splitterAnyOfJsonSchema> = {
   parameters: { controls: { expanded: true } },
   tags: ["autodocs"],
   args: {
-    jsonSchema: anyOfJsonSchema,
+    jsonSchema: splitterAnyOfJsonSchema,
     uiSchema: {
       type: "VerticalLayout",
       elements: [
         {
           type: "Control",
           scope: "#/properties/splitter",
-          options: { optionType: "button" } satisfies OneOfControlOptions,
+          options: { optionType: "button" },
         },
       ],
     },
@@ -89,18 +89,18 @@ export const Button: Story = {
   },
 }
 
-export const Dropdown: Story = {
+export const Dropdown: Story<typeof splitterAnyOfJsonSchema> = {
   parameters: { controls: { expanded: true } },
   tags: ["autodocs"],
   args: {
-    jsonSchema: anyOfJsonSchema,
+    jsonSchema: splitterAnyOfJsonSchema,
     uiSchema: {
       type: "VerticalLayout",
       elements: [
         {
           type: "Control",
           scope: "#/properties/splitter",
-          options: { optionType: "dropdown" } satisfies OneOfControlOptions,
+          options: { optionType: "dropdown" },
         },
       ],
     },

--- a/src/stories/controls/AnyOfControl.stories.tsx
+++ b/src/stories/controls/AnyOfControl.stories.tsx
@@ -54,7 +54,19 @@ export const RadioGroup: Story<typeof splitterAnyOfJsonSchema> = {
     jsonSchema: splitterAnyOfJsonSchema,
     uiSchema: {
       type: "VerticalLayout",
-      elements: [{ type: "Control", scope: "#/properties/splitter" }],
+      elements: [
+        {
+          type: "Control",
+          scope: "#/properties/splitter",
+          options: {
+            subschemaTitleToLabelMap: {
+              SplitterYear: "Year",
+              SplitterYearAndMonthAndDay: "Year - Month - Day",
+              SplitterYearAndMonth: "Year - Month",
+            },
+          },
+        },
+      ],
     },
   },
   argTypes: {

--- a/src/stories/controls/BooleanControl.stories.tsx
+++ b/src/stories/controls/BooleanControl.stories.tsx
@@ -9,6 +9,17 @@ const schema = {
   properties: { checkbox: { type: "boolean" } },
 } satisfies JSONSchema
 
+const metaUISchema = {
+  type: "VerticalLayout",
+  elements: [
+    {
+      type: "Control",
+      scope: "#/properties/checkbox",
+      label: "Checkbox",
+    },
+  ],
+} satisfies UISchema<typeof schema>
+
 const meta: Meta<typeof StorybookAntDJsonForm> = {
   title: "Control/Boolean",
   component: StorybookAntDJsonForm,
@@ -20,16 +31,7 @@ const meta: Meta<typeof StorybookAntDJsonForm> = {
   tags: ["autodocs"],
   args: {
     jsonSchema: schema,
-    uiSchema: {
-      type: "VerticalLayout",
-      elements: [
-        {
-          type: "Control",
-          scope: "#/properties/checkbox",
-          label: "Checkbox",
-        },
-      ],
-    } satisfies UISchema,
+    uiSchema: metaUISchema,
     rendererRegistryEntries: [...rendererRegistryEntries],
   },
   // More on argTypes: https://storybook.js.org/docs/api/argtypes

--- a/src/stories/controls/ObjectArrayControl.stories.tsx
+++ b/src/stories/controls/ObjectArrayControl.stories.tsx
@@ -2,13 +2,13 @@ import type { Meta, StoryObj } from "@storybook/react"
 
 import { rendererRegistryEntries } from "../../renderer-registry-entries"
 import { JSONSchema } from "json-schema-to-ts"
-import { UISchema } from "../../ui-schema"
 import { StorybookAntDJsonForm } from "../../common/StorybookAntDJsonForm"
 import {
   objectArrayControlJsonSchema,
   arrayControlUISchema,
   arrayControlUISchemaWithIcons,
 } from "../../testSchemas/arraySchema"
+import { ComponentProps } from "react"
 
 const meta: Meta<typeof StorybookAntDJsonForm> = {
   title: "Control/Object Array",
@@ -32,17 +32,20 @@ const meta: Meta<typeof StorybookAntDJsonForm> = {
 }
 
 export default meta
-type Story = StoryObj<typeof StorybookAntDJsonForm>
+type Story<T> = StoryObj<ComponentProps<typeof StorybookAntDJsonForm<T>>>
 
-export const ObjectArrayOfStrings: Story = {
-  tags: ["autodocs"],
-  args: {
-    jsonSchema: objectArrayControlJsonSchema,
-    uiSchema: arrayControlUISchema,
-  },
-}
+export const ObjectArrayOfStrings: Story<typeof objectArrayControlJsonSchema> =
+  {
+    tags: ["autodocs"],
+    args: {
+      jsonSchema: objectArrayControlJsonSchema,
+      uiSchema: arrayControlUISchema,
+    },
+  }
 
-export const ObjectArrayWithUiOptionAddButtonTop: Story = {
+export const ObjectArrayWithUiOptionAddButtonTop: Story<
+  typeof objectArrayControlJsonSchema
+> = {
   tags: ["autodocs"],
   args: {
     jsonSchema: objectArrayControlJsonSchema,
@@ -57,11 +60,13 @@ export const ObjectArrayWithUiOptionAddButtonTop: Story = {
           },
         },
       ],
-    } satisfies UISchema,
+    },
   },
 }
 
-export const ObjectArrayWithUiOptionForButtons: Story = {
+export const ObjectArrayWithUiOptionForButtons: Story<
+  typeof objectArrayControlJsonSchema
+> = {
   tags: ["autodocs"],
   args: {
     jsonSchema: objectArrayControlJsonSchema,
@@ -83,11 +88,13 @@ export const ObjectArrayWithUiOptionForButtons: Story = {
           },
         },
       ],
-    } satisfies UISchema,
+    },
   },
 }
 
-export const ObjectArrayWithUiOptionWithIcons: Story = {
+export const ObjectArrayWithUiOptionWithIcons: Story<
+  typeof objectArrayControlJsonSchema
+> = {
   tags: ["autodocs"],
   args: {
     jsonSchema: objectArrayControlJsonSchema,
@@ -95,34 +102,38 @@ export const ObjectArrayWithUiOptionWithIcons: Story = {
   },
 }
 
-export const ObjectArrayWithMultipleProperties: Story = {
-  tags: ["autodocs"],
-  args: {
-    jsonSchema: {
-      type: "object",
-      properties: {
-        guest_list: {
-          type: "array",
-          items: {
-            type: "object",
-            properties: {
-              name: {
-                title: "name",
-                type: "string",
-              },
-              gluten_free: {
-                title: "gluten-free",
-                type: "boolean",
-              },
-              vegan: {
-                title: "vegan",
-                type: "boolean",
-              },
-            },
+const objectArrayMultiplePropertiesJsonSchema = {
+  type: "object",
+  properties: {
+    guest_list: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          name: {
+            title: "name",
+            type: "string",
+          },
+          gluten_free: {
+            title: "gluten-free",
+            type: "boolean",
+          },
+          vegan: {
+            title: "vegan",
+            type: "boolean",
           },
         },
       },
-    } satisfies JSONSchema,
+    },
+  },
+} satisfies JSONSchema
+
+export const ObjectArrayWithMultipleProperties: Story<
+  typeof objectArrayMultiplePropertiesJsonSchema
+> = {
+  tags: ["autodocs"],
+  args: {
+    jsonSchema: objectArrayMultiplePropertiesJsonSchema,
     uiSchema: {
       type: "VerticalLayout",
       elements: [
@@ -141,6 +152,6 @@ export const ObjectArrayWithMultipleProperties: Story = {
           },
         },
       ],
-    } satisfies UISchema,
+    },
   },
 }

--- a/src/stories/controls/OneOfControl.stories.tsx
+++ b/src/stories/controls/OneOfControl.stories.tsx
@@ -1,10 +1,6 @@
 import { Meta, StoryObj } from "@storybook/react"
 import { rendererRegistryEntries } from "../../renderer-registry-entries"
-import {
-  LabelDescription,
-  OneOfControlOptions,
-  UISchema,
-} from "../../ui-schema"
+import { UISchema } from "../../ui-schema"
 import { StorybookAntDJsonForm } from "../../common/StorybookAntDJsonForm"
 import { JSONSchema } from "json-schema-to-ts"
 
@@ -36,6 +32,17 @@ const schema = {
   // required: ["name"],
 } satisfies JSONSchema
 
+const metaUISchema = {
+  type: "VerticalLayout",
+  elements: [
+    {
+      type: "Control",
+      scope: "#/properties/deliveryOption",
+      // label: "Name",
+    },
+  ],
+} satisfies UISchema<typeof schema>
+
 const meta: Meta<typeof StorybookAntDJsonForm> = {
   title: "Control/OneOf",
   component: StorybookAntDJsonForm,
@@ -47,16 +54,7 @@ const meta: Meta<typeof StorybookAntDJsonForm> = {
   tags: ["autodocs"],
   args: {
     jsonSchema: schema,
-    uiSchema: {
-      type: "VerticalLayout",
-      elements: [
-        {
-          type: "Control",
-          scope: "#/properties/deliveryOption",
-          // label: "Name",
-        },
-      ],
-    } satisfies UISchema,
+    uiSchema: metaUISchema,
     rendererRegistryEntries: [...rendererRegistryEntries],
   },
   // More on argTypes: https://storybook.js.org/docs/api/argtypes
@@ -76,15 +74,17 @@ const meta: Meta<typeof StorybookAntDJsonForm> = {
 export default meta
 type Story = StoryObj<typeof StorybookAntDJsonForm>
 
+const radioGroupUISchema = {
+  type: "VerticalLayout",
+  elements: [{ type: "Control", scope: "#/properties/deliveryOption" }],
+} satisfies UISchema<typeof schema>
+
 export const RadioGroup: Story = {
   parameters: { controls: { expanded: true } },
   tags: ["autodocs"],
   args: {
     jsonSchema: schema,
-    uiSchema: {
-      type: "VerticalLayout",
-      elements: [{ type: "Control", scope: "#/properties/deliveryOption" }],
-    },
+    uiSchema: radioGroupUISchema,
   },
   argTypes: {
     jsonSchema: {
@@ -93,22 +93,24 @@ export const RadioGroup: Story = {
     },
   },
 }
+
+const buttonUISchema = {
+  type: "VerticalLayout",
+  elements: [
+    {
+      type: "Control",
+      scope: "#/properties/deliveryOption",
+      options: { optionType: "button" },
+    },
+  ],
+} satisfies UISchema<typeof schema>
 
 export const Button: Story = {
   parameters: { controls: { expanded: true } },
   tags: ["autodocs"],
   args: {
     jsonSchema: schema,
-    uiSchema: {
-      type: "VerticalLayout",
-      elements: [
-        {
-          type: "Control",
-          scope: "#/properties/deliveryOption",
-          options: { optionType: "button" } satisfies OneOfControlOptions,
-        },
-      ],
-    },
+    uiSchema: buttonUISchema,
   },
   argTypes: {
     jsonSchema: {
@@ -117,22 +119,24 @@ export const Button: Story = {
     },
   },
 }
+
+const dropdownUISchema = {
+  type: "VerticalLayout",
+  elements: [
+    {
+      type: "Control",
+      scope: "#/properties/deliveryOption",
+      options: { optionType: "dropdown" },
+    },
+  ],
+} satisfies UISchema<typeof schema>
 
 export const Dropdown: Story = {
   parameters: { controls: { expanded: true } },
   tags: ["autodocs"],
   args: {
     jsonSchema: schema,
-    uiSchema: {
-      type: "VerticalLayout",
-      elements: [
-        {
-          type: "Control",
-          scope: "#/properties/deliveryOption",
-          options: { optionType: "dropdown" } satisfies OneOfControlOptions,
-        },
-      ],
-    },
+    uiSchema: dropdownUISchema,
   },
   argTypes: {
     jsonSchema: {
@@ -141,22 +145,24 @@ export const Dropdown: Story = {
     },
   },
 }
+
+const segmentedUISchema = {
+  type: "VerticalLayout",
+  elements: [
+    {
+      type: "Control",
+      scope: "#/properties/deliveryOption",
+      options: { optionType: "dropdown" },
+    },
+  ],
+} satisfies UISchema<typeof schema>
 
 export const Segmented: Story = {
   parameters: { controls: { expanded: true } },
   tags: ["autodocs"],
   args: {
     jsonSchema: schema,
-    uiSchema: {
-      type: "VerticalLayout",
-      elements: [
-        {
-          type: "Control",
-          scope: "#/properties/deliveryOption",
-          options: { optionType: "segmented" } satisfies OneOfControlOptions,
-        },
-      ],
-    },
+    uiSchema: segmentedUISchema,
   },
   argTypes: {
     jsonSchema: {
@@ -165,27 +171,29 @@ export const Segmented: Story = {
     },
   },
 }
+
+const oneOfTitleUISchema = {
+  type: "VerticalLayout",
+  elements: [
+    {
+      type: "Control",
+      label: {
+        type: "Title",
+        text: "Titles are configurable with AntD Title Props",
+        titleProps: { level: 5, delete: true, type: "danger" },
+      },
+      scope: "#/properties/deliveryOption",
+      options: { optionType: "dropdown" },
+    },
+  ],
+} satisfies UISchema<typeof schema>
 
 export const OneOfTitleLabelStyling: Story = {
   parameters: { controls: { expanded: true } },
   tags: ["autodocs"],
   args: {
     jsonSchema: schema,
-    uiSchema: {
-      type: "VerticalLayout",
-      elements: [
-        {
-          type: "Control",
-          label: {
-            type: "Title",
-            text: "Titles are configurable with AntD Title Props",
-            titleProps: { level: 5, delete: true, type: "danger" },
-          } satisfies LabelDescription,
-          scope: "#/properties/deliveryOption",
-          options: { optionType: "dropdown" } satisfies OneOfControlOptions,
-        },
-      ],
-    },
+    uiSchema: oneOfTitleUISchema,
   },
   argTypes: {
     jsonSchema: {
@@ -195,26 +203,28 @@ export const OneOfTitleLabelStyling: Story = {
   },
 }
 
+const oneOfTextLabelStylingUISchema = {
+  type: "VerticalLayout",
+  elements: [
+    {
+      type: "Control",
+      label: {
+        type: "Text",
+        text: "Titles are configurable with AntD Title Props",
+        textProps: { disabled: true, type: "secondary" },
+      },
+      scope: "#/properties/deliveryOption",
+      options: { optionType: "dropdown" },
+    },
+  ],
+} satisfies UISchema<typeof schema>
+
 export const OneOfTextLabelStyling: Story = {
   parameters: { controls: { expanded: true } },
   tags: ["autodocs"],
   args: {
     jsonSchema: schema,
-    uiSchema: {
-      type: "VerticalLayout",
-      elements: [
-        {
-          type: "Control",
-          label: {
-            type: "Text",
-            text: "Titles are configurable with AntD Title Props",
-            textProps: { disabled: true, type: "secondary" },
-          },
-          scope: "#/properties/deliveryOption",
-          options: { optionType: "dropdown" } satisfies OneOfControlOptions,
-        },
-      ],
-    },
+    uiSchema: oneOfTextLabelStylingUISchema,
   },
   argTypes: {
     jsonSchema: {

--- a/src/stories/controls/TextControl.stories.tsx
+++ b/src/stories/controls/TextControl.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from "@storybook/react"
 import { rendererRegistryEntries } from "../../renderer-registry-entries"
-import { TextControlOptions, UISchema } from "../../ui-schema"
+import { UISchema } from "../../ui-schema"
 import { StorybookAntDJsonForm } from "../../common/StorybookAntDJsonForm"
 import { JSONSchema } from "json-schema-to-ts"
 
@@ -30,7 +30,7 @@ const meta: Meta<typeof StorybookAntDJsonForm> = {
           label: "Name",
         },
       ],
-    } satisfies UISchema,
+    } satisfies UISchema<typeof schema>,
     rendererRegistryEntries: [...rendererRegistryEntries],
   },
   // More on argTypes: https://storybook.js.org/docs/api/argtypes
@@ -76,7 +76,7 @@ export const MultiLine: Story = {
           options: { type: "multiline" },
         },
       ],
-    } satisfies UISchema,
+    } satisfies UISchema<typeof schema>,
   },
 }
 
@@ -90,10 +90,10 @@ export const Password: Story = {
           type: "Control",
           scope: "#/properties/name",
           label: "Name",
-          options: { type: "password" },
+          options: { type: "password", rules: [] },
         },
       ],
-    } satisfies UISchema,
+    } satisfies UISchema<typeof schema>,
   },
 }
 
@@ -114,9 +114,9 @@ export const RuleDefinedInUISchema: Story = {
                 message: "Name cannot start or end with a space",
               },
             ],
-          } satisfies TextControlOptions,
+          },
         },
       ],
-    } satisfies UISchema,
+    } satisfies UISchema<typeof schema>,
   },
 }

--- a/src/stories/layouts/AlertLayout.stories.tsx
+++ b/src/stories/layouts/AlertLayout.stories.tsx
@@ -57,7 +57,7 @@ export const Info: Story = {
           },
         },
       ],
-    } satisfies UISchema,
+    } satisfies UISchema<typeof schema>,
   },
 }
 
@@ -76,7 +76,7 @@ export const Warning: Story = {
           },
         },
       ],
-    } satisfies UISchema,
+    } satisfies UISchema<typeof schema>,
   },
 }
 
@@ -95,6 +95,6 @@ export const Success: Story = {
           },
         },
       ],
-    } satisfies UISchema,
+    } satisfies UISchema<typeof schema>,
   },
 }

--- a/src/stories/layouts/GroupLayout.stories.tsx
+++ b/src/stories/layouts/GroupLayout.stories.tsx
@@ -45,9 +45,9 @@ const meta: Meta<typeof StorybookAntDJsonForm> = {
 }
 
 export default meta
-type Story = StoryObj<typeof StorybookAntDJsonForm>
+type Story<T> = StoryObj<typeof StorybookAntDJsonForm<T>>
 
-export const Divider: Story = {
+export const Divider: Story<typeof reindeerSchema> = {
   tags: ["autodocs"],
   args: {
     jsonSchema: reindeerSchema,
@@ -76,11 +76,11 @@ export const Divider: Story = {
           ],
         },
       ],
-    } satisfies UISchema,
+    } satisfies UISchema<typeof reindeerSchema>,
   },
 }
 
-export const DividerWithCustomStyles: Story = {
+export const DividerWithCustomStyles: Story<typeof reindeerSchema> = {
   tags: ["autodocs"],
   args: {
     jsonSchema: reindeerSchema,
@@ -118,11 +118,11 @@ export const DividerWithCustomStyles: Story = {
           ],
         },
       ],
-    } satisfies UISchema,
+    } satisfies UISchema<typeof reindeerSchema>,
   },
 }
 
-export const Card: Story = {
+export const Card: Story<typeof addressSchema> = {
   tags: ["autodocs"],
   args: {
     jsonSchema: addressSchema,
@@ -153,6 +153,6 @@ export const Card: Story = {
           ],
         },
       ],
-    } satisfies UISchema,
+    } satisfies UISchema<typeof addressSchema>,
   },
 }

--- a/src/testSchemas/anyOfSchema.ts
+++ b/src/testSchemas/anyOfSchema.ts
@@ -6,7 +6,9 @@ import {
 import { UISchema } from "../ui-schema"
 import { JSONSchema } from "json-schema-to-ts"
 
-const splitterUISchema: UISchema = {
+const splitterUISchema: UISchema<
+  typeof splitterAnyOfJsonSchema.definitions.SplitterYear
+> = {
   type: "VerticalLayout",
   elements: [
     {
@@ -40,7 +42,7 @@ export const SplitterUISchemaRegistryEntry: JsonFormsUISchemaRegistryEntry = {
   },
 }
 
-export const anyOfJsonSchema = {
+export const splitterAnyOfJsonSchema = {
   type: "object",
   properties: {
     splitter: {
@@ -78,7 +80,7 @@ export const anyOfJsonSchema = {
       },
       required: ["column_name"],
       additionalProperties: false,
-    } as JSONSchema,
+    },
     SplitterYearAndMonth: {
       const: "SplitterYearAndMonth",
       title: "Year - Month",
@@ -98,7 +100,7 @@ export const anyOfJsonSchema = {
       },
       required: ["column_name"],
       additionalProperties: false,
-    } as JSONSchema,
+    },
     SplitterYearAndMonthAndDay: {
       const: "SplitterYearAndMonthAndDay",
       title: "Year - Month - Day",
@@ -117,7 +119,7 @@ export const anyOfJsonSchema = {
       },
       required: ["column_name"],
       additionalProperties: false,
-    } as JSONSchema,
+    },
   },
   required: ["splitter"],
   additionalProperties: false,

--- a/src/testSchemas/anyOfSchema.ts
+++ b/src/testSchemas/anyOfSchema.ts
@@ -62,9 +62,7 @@ export const splitterAnyOfJsonSchema = {
   },
   definitions: {
     SplitterYear: {
-      title: "Year",
-      const: "SplitterYear",
-      // "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+      title: "SplitterYear",
       type: "object",
       properties: {
         column_name: {
@@ -82,9 +80,7 @@ export const splitterAnyOfJsonSchema = {
       additionalProperties: false,
     },
     SplitterYearAndMonth: {
-      const: "SplitterYearAndMonth",
-      title: "Year - Month",
-      // "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+      title: "SplitterYearAndMonth",
       type: "object",
       properties: {
         column_name: {
@@ -102,8 +98,7 @@ export const splitterAnyOfJsonSchema = {
       additionalProperties: false,
     },
     SplitterYearAndMonthAndDay: {
-      const: "SplitterYearAndMonthAndDay",
-      title: "Year - Month - Day",
+      title: "SplitterYearAndMonthAndDay",
       type: "object",
       properties: {
         column_name: {

--- a/src/testSchemas/arraySchema.tsx
+++ b/src/testSchemas/arraySchema.tsx
@@ -10,7 +10,7 @@ export const arrayControlUISchema = {
       type: "Control",
     },
   ],
-} satisfies UISchema
+} satisfies UISchema<typeof objectArrayControlJsonSchema>
 
 export const arrayControlUISchemaWithIcons = {
   type: "VerticalLayout",
@@ -33,7 +33,7 @@ export const arrayControlUISchemaWithIcons = {
       },
     },
   ],
-} satisfies UISchema
+} satisfies UISchema<typeof objectArrayControlJsonSchema>
 
 export const objectArrayControlJsonSchema = {
   title: "Assets",

--- a/src/testSchemas/numericSchema.ts
+++ b/src/testSchemas/numericSchema.ts
@@ -87,7 +87,7 @@ export const numericVerticalUISchema = {
       scope: "#/properties/numericValue",
     },
   ],
-} satisfies UISchema
+} satisfies UISchema<typeof numericROISchema>
 
 export const numericHorizontalUISchema = {
   type: "HorizontalLayout",
@@ -97,7 +97,7 @@ export const numericHorizontalUISchema = {
       scope: "#/properties/numericValue",
     },
   ],
-} satisfies UISchema
+} satisfies UISchema<typeof numericROISchema>
 
 export const numericUSDUISchema = {
   type: "VerticalLayout",
@@ -110,7 +110,7 @@ export const numericUSDUISchema = {
       },
     },
   ],
-} satisfies UISchema
+} satisfies UISchema<typeof numericROISchema>
 
 export const numericPercentageUISchema = {
   type: "VerticalLayout",
@@ -123,7 +123,7 @@ export const numericPercentageUISchema = {
       },
     },
   ],
-} satisfies UISchema
+} satisfies UISchema<typeof numericROISchema>
 
 export const numericUISchemaWithRule = {
   type: "VerticalLayout",
@@ -137,4 +137,4 @@ export const numericUISchemaWithRule = {
       },
     },
   ],
-} satisfies UISchema
+} satisfies UISchema<typeof numericROISchema>

--- a/src/testSchemas/numericSliderSchema.ts
+++ b/src/testSchemas/numericSliderSchema.ts
@@ -96,7 +96,7 @@ export const numericSliderVerticalUISchema = {
       scope: "#/properties/numericRangeValue",
     },
   ],
-} satisfies UISchema
+} satisfies UISchema<typeof numericSliderDonateNowSchema>
 
 export const numericSliderHorizontalUISchema = {
   type: "HorizontalLayout",
@@ -106,7 +106,7 @@ export const numericSliderHorizontalUISchema = {
       scope: "#/properties/numericRangeValue",
     },
   ],
-} satisfies UISchema
+} satisfies UISchema<typeof numericSliderDonateNowSchema>
 
 export const numericSliderUSDUISchema = {
   type: "VerticalLayout",
@@ -119,7 +119,7 @@ export const numericSliderUSDUISchema = {
       },
     },
   ],
-} satisfies UISchema
+} satisfies UISchema<typeof numericSliderDonateNowSchema>
 
 export const numericSliderPercentageUISchema = {
   type: "VerticalLayout",
@@ -132,7 +132,7 @@ export const numericSliderPercentageUISchema = {
       },
     },
   ],
-} satisfies UISchema
+} satisfies UISchema<typeof numericSliderDonateNowSchema>
 
 export const numericSliderTemperatureUISchema = {
   type: "VerticalLayout",
@@ -145,7 +145,7 @@ export const numericSliderTemperatureUISchema = {
       },
     },
   ],
-} satisfies UISchema
+} satisfies UISchema<typeof numericSliderDonateNowSchema>
 
 export const numericSliderUISchemaWithRule = {
   type: "VerticalLayout",
@@ -159,4 +159,4 @@ export const numericSliderUISchemaWithRule = {
       },
     },
   ],
-} satisfies UISchema
+} satisfies UISchema<typeof numericSliderDonateNowSchema>

--- a/src/testSchemas/objectArraySchema.tsx
+++ b/src/testSchemas/objectArraySchema.tsx
@@ -10,7 +10,7 @@ export const objectArrayControlUISchema = {
       type: "Control",
     },
   ],
-} satisfies UISchema
+} satisfies UISchema<typeof objectArrayControlJsonSchema>
 
 export const objectArrayControlJsonSchema = {
   title: "Assets",
@@ -72,4 +72,4 @@ export const objectArrayControlUISchemaWithIcons = {
       },
     },
   ],
-} satisfies UISchema
+} satisfies UISchema<typeof objectArrayControlJsonSchemaWithRequired>

--- a/src/testSchemas/objectSchema.ts
+++ b/src/testSchemas/objectSchema.ts
@@ -26,7 +26,7 @@ export const objectUISchemaWithName = {
       scope: "#/properties/name",
     },
   ],
-} satisfies UISchema
+} satisfies UISchema<typeof objectSchema>
 
 export const objectUISchemaWithNameAndLastName = {
   type: "VerticalLayout",
@@ -40,7 +40,7 @@ export const objectUISchemaWithNameAndLastName = {
       scope: "#/properties/lastName",
     },
   ],
-} satisfies UISchema
+} satisfies UISchema<typeof objectSchema>
 
 export const objectUISchemaWithRule = {
   type: "VerticalLayout",
@@ -61,4 +61,4 @@ export const objectUISchemaWithRule = {
       },
     },
   ],
-} satisfies UISchema
+} satisfies UISchema<typeof objectSchema>

--- a/src/ui-schema.ts
+++ b/src/ui-schema.ts
@@ -99,13 +99,15 @@ interface LayoutUISchema<T extends string> extends UISchemaElement<T> {
 /**
  * A layout which orders its child elements vertically (i.e. from top to bottom).
  */
-export interface VerticalLayoutUISchema<T extends string> extends LayoutUISchema<T> {
+export interface VerticalLayoutUISchema<T extends string>
+  extends LayoutUISchema<T> {
   type: "VerticalLayout"
 }
 /**
  * A layout which orders its children horizontally (i.e. from left to right).
  */
-export interface HorizontalLayoutUISchema<T extends string> extends LayoutUISchema<T> {
+export interface HorizontalLayoutUISchema<T extends string>
+  extends LayoutUISchema<T> {
   type: "HorizontalLayout"
 }
 /**
@@ -207,9 +209,7 @@ type ControlOptions =
 
 const ObjectUISchema: UISchema<Paths<typeof objectSchema>> = {
   type: "VerticalLayout",
-  elements: [
-    {type: "Control", scope: "#/properties/name"}
-  ]
+  elements: [{ type: "Control", scope: "#/properties/name" }],
 } // satisfies UISchema<Paths<typeof objectSchema>>
 
 console.log(ObjectUISchema)

--- a/src/ui-schema.ts
+++ b/src/ui-schema.ts
@@ -131,20 +131,22 @@ export type AlertLayoutOptions = { type: AlertProps["type"] }
 // this is intended to be a union, it just has one member rn
 export type LabelOptions = AlertLayoutOptions
 
-export const OneOfControlOptions = [
+export const CombinatorSchemaSwitcherOptions = [
   "button",
   "dropdown",
   "radio",
-  "toggle",
   "segmented",
 ] as const
 
-export type OneOfControlOption = (typeof OneOfControlOptions)[number]
+export type CombinatorSchemaSwitcherOption = (typeof CombinatorSchemaSwitcherOptions)[number]
 
 export type OneOfControlOptions = {
-  optionType?: OneOfControlOption
-  toggleLabel?: string
+  optionType?: CombinatorSchemaSwitcherOption
+  required?: boolean
+  subschemaTitleToLabelMap?: Record<string, string>
 }
+
+export type AnyOfControlOptions = OneOfControlOptions
 
 export type TextControlType = "multiline" | "password" | "singleline"
 
@@ -155,14 +157,6 @@ export type TextControlOptions = {
   required?: boolean
   rules?: AntDRule[]
 }
-
-export type AnyOfControlOptions = {
-  optionType?: AnyOfControlOption
-  required?: boolean
-}
-
-export const AnyOfControlOptions = ["button", "dropdown", "radio"] as const
-export type AnyOfControlOption = (typeof AnyOfControlOptions)[number]
 
 /**
  * A control element. The scope property of the control determines

--- a/src/ui-schema.ts
+++ b/src/ui-schema.ts
@@ -138,7 +138,8 @@ export const CombinatorSchemaSwitcherOptions = [
   "segmented",
 ] as const
 
-export type CombinatorSchemaSwitcherOption = (typeof CombinatorSchemaSwitcherOptions)[number]
+export type CombinatorSchemaSwitcherOption =
+  (typeof CombinatorSchemaSwitcherOptions)[number]
 
 export type OneOfControlOptions = {
   optionType?: CombinatorSchemaSwitcherOption


### PR DESCRIPTION
Let’s say you have a json schema that looks like this:
```
export const mySchema = {
  type: "object",
  properties: { name: { type: "string" } },
} satisfies JSONSchema
```
and you want to make a UI Schema for it:
```
const myUISchema = { 
  type: "Control",
  scope: "#/properties/name"
} satisfies UISchema
```
Misspelling or forgetting the exact right syntax for the `scope` property results in difficult to diagnose bugs. It's also tricky to understand when certain option types (specific to renderers) are available. This PR introduces a recursive `SchemaAwareScope` type that builds a union of types where:
1. The `scope` property is always a valid path in a jsonschema
2. The `options` property is typechecked against jsonschema property type
You just have to provide the type of the jsonschema object to the UISchema type!
```
const schema = {
  type: "object",
  properties: {
    person: {
      oneOf: [...]
...
const uiSchema: UISchema<typeof schema> = {
  type: "Control",
  scope: "#/properties/person",
  options: { optionType: "button" },
}
```