### PR TITLE
feat: Allow arrays to be sortable

### DIFF
--- a/src/controls/ObjectArrayControl.test.tsx
+++ b/src/controls/ObjectArrayControl.test.tsx
@@ -122,7 +122,9 @@ describe("ObjectArrayControl", () => {
 
   test("renders with overwritten icons and does not allow overwriting onClick", async () => {
     const user = userEvent.setup()
-    let data: JSONFormData<typeof objectArrayControlJsonSchema> = { assets: [] }
+    let data: JSONFormData<typeof objectArrayControlJsonSchema> = {
+      assets: [{ asset: "one" }],
+    }
     render({
       schema: objectArrayControlJsonSchema,
       uischema: arrayControlUISchemaWithIcons,
@@ -135,24 +137,14 @@ describe("ObjectArrayControl", () => {
     screen.getByText("Add more items")
     screen.getByLabelText("plus-circle") // fyi: aria-label is "plus-circle"
 
-    await screen.findByRole("textbox")
-    await waitFor(() => {
-      expect(data).toEqual({
-        assets: [{}],
-      })
-    })
-
     // Delete button text is overwritten and has the correct icon
-    await screen.findByText("Destroy me!")
+    const deleteButton = await screen.findByText("Destroy me!")
     await screen.findByLabelText("delete") // fyi: aria-label is "delete"
 
-    // Check that the onClick handler is not overwritten on Delete button
-    const deleteButton = await screen.findByText("Destroy me!")
+    // Check that the empty onClick handler is not overwritten on Delete button
     await user.click(deleteButton)
     await waitFor(() => {
-      expect(data).toEqual({
-        assets: [],
-      })
+      expect(data.assets?.length).toEqual(1)
     })
   })
 

--- a/src/controls/PrimitiveArrayControl.test.tsx
+++ b/src/controls/PrimitiveArrayControl.test.tsx
@@ -213,8 +213,12 @@ describe("PrimitiveArrayControl", () => {
     expect(moveUpButtons[0]).toHaveProperty("disabled", true)
     expect(moveDownButtons[3]).toHaveProperty("disabled", true)
     await user.click(moveUpButtons[3])
-    expect(data).toEqual({ assets: ["A", "B", "D", "C"] })
+    await waitFor(() => {
+      expect(data).toEqual({ assets: ["A", "B", "D", "C"] })
+    })
     await user.click(moveDownButtons[0])
-    expect(data).toEqual({ assets: ["B", "A", "D", "C"] })
+    await waitFor(() => {
+      expect(data).toEqual({ assets: ["B", "A", "D", "C"] })
+    })
   })
 })

--- a/src/controls/PrimitiveArrayControl.test.tsx
+++ b/src/controls/PrimitiveArrayControl.test.tsx
@@ -10,6 +10,7 @@ import {
   stringArrayControlJsonSchemaWithTitle,
   numberArrayControlJsonSchema,
   arrayInsideCombinatorSchema,
+  arrayControlSortableUISchema,
 } from "../testSchemas/arraySchema"
 import { UISchema } from "../ui-schema"
 import { JSONFormData } from "../common/schema-derived-types"
@@ -27,17 +28,22 @@ describe("PrimitiveArrayControl", () => {
   test.each([
     [stringArrayControlJsonSchema],
     [stringArrayControlJsonSchemaWithRequired],
-  ])("does not render remove button with one element", async (schema) => {
-    render({
-      schema: schema,
-      uischema: arrayControlUISchema,
-      data: { assets: ["my asset"] },
-    })
-    await screen.findByText("Add Assets")
-    screen.getByDisplayValue("my asset")
-    //note: the text is within a span in the <button>
-    expect(screen.queryByRole("button", { name: "Delete" })).toBeNull()
-  })
+  ])(
+    "does not render remove, up, or down buttons with only one element",
+    async (schema) => {
+      render({
+        schema: schema,
+        uischema: arrayControlSortableUISchema,
+        data: { assets: ["my asset"] },
+      })
+      await screen.findByText("Add Assets")
+      screen.getByDisplayValue("my asset")
+      //note: the text is within a span in the <button>
+      expect(screen.queryByRole("button", { name: "Delete" })).toBeNull()
+      expect(screen.queryByLabelText(/move up/i)).toBeNull()
+      expect(screen.queryByLabelText(/move down/i)).toBeNull()
+    },
+  )
 
   test.each([
     [stringArrayControlJsonSchema],
@@ -185,5 +191,30 @@ describe("PrimitiveArrayControl", () => {
     await screen.findByLabelText("Assets 2")
     await screen.findByLabelText("Assets 3")
     await screen.findByLabelText("Assets 4")
+  })
+  test("Arrays are sortable", async () => {
+    let data: JSONFormData<typeof stringArrayControlJsonSchema> = {
+      assets: ["A", "B", "C", "D"],
+    }
+    const user = userEvent.setup()
+    render({
+      schema: stringArrayControlJsonSchema,
+      uischema: arrayControlSortableUISchema,
+      data: data,
+      onChange: (result) => {
+        data = result.data as JSONFormData<typeof stringArrayControlJsonSchema>
+      },
+    })
+
+    const moveUpButtons = await screen.findAllByLabelText(/move up/i)
+    const moveDownButtons = await screen.findAllByLabelText(/move down/i)
+    expect(moveUpButtons).toHaveLength(4)
+    expect(moveDownButtons).toHaveLength(4)
+    expect(moveUpButtons[0]).toHaveProperty("disabled", true)
+    expect(moveDownButtons[3]).toHaveProperty("disabled", true)
+    await user.click(moveUpButtons[3])
+    expect(data).toEqual({ assets: ["A", "B", "D", "C"] })
+    await user.click(moveDownButtons[0])
+    expect(data).toEqual({ assets: ["B", "A", "D", "C"] })
   })
 })

--- a/src/controls/PrimitiveArrayControl.test.tsx
+++ b/src/controls/PrimitiveArrayControl.test.tsx
@@ -11,6 +11,7 @@ import {
   numberArrayControlJsonSchema,
   arrayInsideCombinatorSchema,
   arrayControlSortableUISchema,
+  arrayControlSortableWithIconsUISchema,
 } from "../testSchemas/arraySchema"
 import { UISchema } from "../ui-schema"
 import { JSONFormData } from "../common/schema-derived-types"
@@ -219,6 +220,39 @@ describe("PrimitiveArrayControl", () => {
     await user.click(moveDownButtons[0])
     await waitFor(() => {
       expect(data).toEqual({ assets: ["B", "A", "D", "C"] })
+    })
+  })
+
+  test("renders with overwritten sorting icons and does not allow overwriting onClick", async () => {
+    const user = userEvent.setup()
+    let data: JSONFormData<typeof stringArrayControlJsonSchema> = {
+      assets: ["A", "B"],
+    }
+    render({
+      schema: stringArrayControlJsonSchema,
+      uischema: arrayControlSortableWithIconsUISchema,
+      data,
+      onChange: (result) => {
+        data = result.data as JSONFormData<typeof stringArrayControlJsonSchema>
+      },
+    })
+
+    // Move buttons text is overwritten with the UISchema's icons
+    const upButtons = await screen.findAllByRole("img", { name: "arrow-up" })
+    const downButtons = await screen.findAllByRole("img", {
+      name: "arrow-down",
+    })
+    expect(screen.queryByText("Up")).toBeNull()
+    expect(screen.queryByText("Down")).toBeNull()
+
+    // Check that the onClick handlers are not overwritten by the UISchema
+    await user.click(upButtons[1])
+    await waitFor(() => {
+      expect(data).toEqual({ assets: ["B", "A"] })
+    })
+    await user.click(downButtons[0])
+    await waitFor(() => {
+      expect(data).toEqual({ assets: ["A", "B"] })
     })
   })
 })

--- a/src/controls/PrimitiveArrayControl.tsx
+++ b/src/controls/PrimitiveArrayControl.tsx
@@ -73,6 +73,14 @@ export function PrimitiveArrayControl({
   const formItemProps =
     "formItemProps" in uischema ? uischema.formItemProps : {}
 
+  const moveUp = (path: string, index: number) => () => {
+    return props.moveUp?.(path, index)()
+  }
+
+  const moveDown = (path: string, index: number) => () => {
+    return props.moveDown?.(path, index)()
+  }
+
   return (
     <Form.Item
       id={id}
@@ -103,6 +111,7 @@ export function PrimitiveArrayControl({
                   </Col>
                   <Col>
                     {fields.length > 1 ? (
+                      <>
                       <Button
                         key="remove"
                         disabled={
@@ -118,6 +127,13 @@ export function PrimitiveArrayControl({
                       >
                         {options.removeButtonProps?.children ?? "Delete"}
                       </Button>
+                        {options.showSortButtons && (
+                          <>
+                        <Button onClick={moveUp(path, index)}>Up</Button>
+                        <Button onClick={moveDown(path, index)}>Down</Button>
+                          </>
+                          )}
+                      </>
                     ) : null}
                   </Col>
                 </Row>

--- a/src/controls/PrimitiveArrayControl.tsx
+++ b/src/controls/PrimitiveArrayControl.tsx
@@ -97,6 +97,24 @@ export function PrimitiveArrayControl({
             <Col>
               {fields.map((field, index) => (
                 <Row key={field.key} gutter={12}>
+                  {fields.length > 1 && options.showSortButtons ? (
+                    <Col>
+                      <Space>
+                      <Button
+                        aria-label={`Move up`}
+                        disabled={index === 0}
+                        {...options.moveUpButtonProps}
+                        onClick={handleUpClick(path, index)}
+                      />
+                      <Button
+                        aria-label={`Move down`}
+                        disabled={index === fields.length - 1}
+                        {...options.moveDownButtonProps}
+                        onClick={handleDownClick(path, index)}
+                      />
+                      </Space>
+                    </Col>
+                  ) : null}
                   <Col>
                     <JsonFormsDispatch
                       enabled={enabled} // not crazy about this pattern of overriding the description, but it solves the problem of disappearing aria labels
@@ -113,23 +131,6 @@ export function PrimitiveArrayControl({
                   </Col>
                   {fields.length > 1 ? (
                     <Col>
-                      <Space align="start">
-                        {options.showSortButtons && (
-                          <>
-                            <Button
-                              aria-label={`Move up`}
-                              disabled={index === 0}
-                              {...options.moveUpButtonProps}
-                              onClick={handleUpClick(path, index)}
-                            />
-                            <Button
-                              aria-label={`Move down`}
-                              disabled={index === fields.length - 1}
-                              {...options.moveDownButtonProps}
-                              onClick={handleDownClick(path, index)}
-                            />
-                          </>
-                        )}
                         <Button
                           key="remove"
                           disabled={
@@ -145,7 +146,6 @@ export function PrimitiveArrayControl({
                         >
                           {options.removeButtonProps?.children ?? "Delete"}
                         </Button>
-                      </Space>
                     </Col>
                   ) : null}
                 </Row>

--- a/src/controls/PrimitiveArrayControl.tsx
+++ b/src/controls/PrimitiveArrayControl.tsx
@@ -9,7 +9,8 @@ import {
   JsonFormsDispatch,
   withJsonFormsArrayControlProps,
 } from "@jsonforms/react"
-import { Form, Button, Col, Row } from "antd"
+import { Form, Button, Col, Row, Space } from "antd"
+import { ArrowUpOutlined, ArrowDownOutlined } from "@ant-design/icons"
 import React, { useEffect, useMemo } from "react"
 import { ArrayControlOptions, ControlUISchema } from "../ui-schema"
 import { usePreviousValue } from "../common/usePreviousValue"
@@ -109,35 +110,41 @@ export function PrimitiveArrayControl({
                       uischemas={uischemas}
                     />
                   </Col>
-                  <Col>
-                    {fields.length > 1 ? (
-                      <>
-                        <Button
-                          key="remove"
-                          disabled={
-                            !removeItems ||
-                            (required && fields.length === 1 && index === 0)
-                          }
-                          {...options.removeButtonProps}
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            remove(field.name)
-                            removeItems?.(path, [index])()
-                          }}
-                        >
-                          {options.removeButtonProps?.children ?? "Delete"}
-                        </Button>
-                        {options.showSortButtons && (
-                          <>
-                            <Button onClick={moveUp(path, index)}>Up</Button>
-                            <Button onClick={moveDown(path, index)}>
-                              Down
-                            </Button>
-                          </>
-                        )}
-                      </>
-                    ) : null}
-                  </Col>
+                  {fields.length > 1 ? (
+                    <Col>
+                      <Space align="start">
+                          {options.showSortButtons && (
+                            <>
+                              <Button
+                                icon={<ArrowUpOutlined />}
+                                onClick={moveUp(path, index)}
+                                disabled={index === 0}
+                              />
+                              <Button
+                                icon={<ArrowDownOutlined />}
+                                onClick={moveDown(path, index)}
+                                disabled={index === fields.length - 1}
+                              />
+                            </>
+                          )}
+                          <Button
+                            key="remove"
+                            disabled={
+                              !removeItems ||
+                              (required && fields.length === 1 && index === 0)
+                            }
+                            {...options.removeButtonProps}
+                            onClick={(e) => {
+                              e.stopPropagation()
+                              remove(field.name)
+                              removeItems?.(path, [index])()
+                            }}
+                          >
+                            {options.removeButtonProps?.children ?? "Delete"}
+                          </Button>
+                      </Space>
+                    </Col>
+                  ) : null}
                 </Row>
               ))}
               <Form.Item>

--- a/src/controls/PrimitiveArrayControl.tsx
+++ b/src/controls/PrimitiveArrayControl.tsx
@@ -105,13 +105,17 @@ export function PrimitiveArrayControl({
                           disabled={index === 0}
                           {...options.moveUpButtonProps}
                           onClick={handleUpClick(path, index)}
-                        />
+                        >
+                          {!options.moveUpButtonProps?.icon && "Up"}
+                        </Button>
                         <Button
                           aria-label={`Move down`}
                           disabled={index === fields.length - 1}
                           {...options.moveDownButtonProps}
                           onClick={handleDownClick(path, index)}
-                        />
+                        >
+                          {!options.moveDownButtonProps?.icon && "Down"}
+                        </Button>
                       </Space>
                     </Col>
                   ) : null}

--- a/src/controls/PrimitiveArrayControl.tsx
+++ b/src/controls/PrimitiveArrayControl.tsx
@@ -10,7 +10,6 @@ import {
   withJsonFormsArrayControlProps,
 } from "@jsonforms/react"
 import { Form, Button, Col, Row, Space } from "antd"
-import { ArrowUpOutlined, ArrowDownOutlined } from "@ant-design/icons"
 import React, { useEffect, useMemo } from "react"
 import { ArrayControlOptions, ControlUISchema } from "../ui-schema"
 import { usePreviousValue } from "../common/usePreviousValue"
@@ -35,6 +34,8 @@ export function PrimitiveArrayControl({
   rootSchema,
   uischemas,
   required,
+  moveDown,
+  moveUp,
   ...props
 }: ArrayControlProps) {
   const foundUISchema = useMemo(
@@ -74,12 +75,12 @@ export function PrimitiveArrayControl({
   const formItemProps =
     "formItemProps" in uischema ? uischema.formItemProps : {}
 
-  const moveUp = (path: string, index: number) => () => {
-    return props.moveUp?.(path, index)()
+  const handleUpClick = (path: string, index: number) => () => {
+    return moveUp?.(path, index)()
   }
 
-  const moveDown = (path: string, index: number) => () => {
-    return props.moveDown?.(path, index)()
+  const handleDownClick = (path: string, index: number) => () => {
+    return moveDown?.(path, index)()
   }
 
   return (
@@ -113,35 +114,37 @@ export function PrimitiveArrayControl({
                   {fields.length > 1 ? (
                     <Col>
                       <Space align="start">
-                          {options.showSortButtons && (
-                            <>
-                              <Button
-                                icon={<ArrowUpOutlined />}
-                                onClick={moveUp(path, index)}
-                                disabled={index === 0}
-                              />
-                              <Button
-                                icon={<ArrowDownOutlined />}
-                                onClick={moveDown(path, index)}
-                                disabled={index === fields.length - 1}
-                              />
-                            </>
-                          )}
-                          <Button
-                            key="remove"
-                            disabled={
-                              !removeItems ||
-                              (required && fields.length === 1 && index === 0)
-                            }
-                            {...options.removeButtonProps}
-                            onClick={(e) => {
-                              e.stopPropagation()
-                              remove(field.name)
-                              removeItems?.(path, [index])()
-                            }}
-                          >
-                            {options.removeButtonProps?.children ?? "Delete"}
-                          </Button>
+                        {options.showSortButtons && (
+                          <>
+                            <Button
+                              aria-label={`Move up`}
+                              disabled={index === 0}
+                              {...options.moveUpButtonProps}
+                              onClick={handleUpClick(path, index)}
+                            />
+                            <Button
+                              aria-label={`Move down`}
+                              disabled={index === fields.length - 1}
+                              {...options.moveDownButtonProps}
+                              onClick={handleDownClick(path, index)}
+                            />
+                          </>
+                        )}
+                        <Button
+                          key="remove"
+                          disabled={
+                            !removeItems ||
+                            (required && fields.length === 1 && index === 0)
+                          }
+                          {...options.removeButtonProps}
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            remove(field.name)
+                            removeItems?.(path, [index])()
+                          }}
+                        >
+                          {options.removeButtonProps?.children ?? "Delete"}
+                        </Button>
                       </Space>
                     </Col>
                   ) : null}

--- a/src/controls/PrimitiveArrayControl.tsx
+++ b/src/controls/PrimitiveArrayControl.tsx
@@ -112,27 +112,29 @@ export function PrimitiveArrayControl({
                   <Col>
                     {fields.length > 1 ? (
                       <>
-                      <Button
-                        key="remove"
-                        disabled={
-                          !removeItems ||
-                          (required && fields.length === 1 && index === 0)
-                        }
-                        {...options.removeButtonProps}
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          remove(field.name)
-                          removeItems?.(path, [index])()
-                        }}
-                      >
-                        {options.removeButtonProps?.children ?? "Delete"}
-                      </Button>
+                        <Button
+                          key="remove"
+                          disabled={
+                            !removeItems ||
+                            (required && fields.length === 1 && index === 0)
+                          }
+                          {...options.removeButtonProps}
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            remove(field.name)
+                            removeItems?.(path, [index])()
+                          }}
+                        >
+                          {options.removeButtonProps?.children ?? "Delete"}
+                        </Button>
                         {options.showSortButtons && (
                           <>
-                        <Button onClick={moveUp(path, index)}>Up</Button>
-                        <Button onClick={moveDown(path, index)}>Down</Button>
+                            <Button onClick={moveUp(path, index)}>Up</Button>
+                            <Button onClick={moveDown(path, index)}>
+                              Down
+                            </Button>
                           </>
-                          )}
+                        )}
                       </>
                     ) : null}
                   </Col>

--- a/src/controls/PrimitiveArrayControl.tsx
+++ b/src/controls/PrimitiveArrayControl.tsx
@@ -100,18 +100,18 @@ export function PrimitiveArrayControl({
                   {fields.length > 1 && options.showSortButtons ? (
                     <Col>
                       <Space>
-                      <Button
-                        aria-label={`Move up`}
-                        disabled={index === 0}
-                        {...options.moveUpButtonProps}
-                        onClick={handleUpClick(path, index)}
-                      />
-                      <Button
-                        aria-label={`Move down`}
-                        disabled={index === fields.length - 1}
-                        {...options.moveDownButtonProps}
-                        onClick={handleDownClick(path, index)}
-                      />
+                        <Button
+                          aria-label={`Move up`}
+                          disabled={index === 0}
+                          {...options.moveUpButtonProps}
+                          onClick={handleUpClick(path, index)}
+                        />
+                        <Button
+                          aria-label={`Move down`}
+                          disabled={index === fields.length - 1}
+                          {...options.moveDownButtonProps}
+                          onClick={handleDownClick(path, index)}
+                        />
                       </Space>
                     </Col>
                   ) : null}
@@ -131,21 +131,21 @@ export function PrimitiveArrayControl({
                   </Col>
                   {fields.length > 1 ? (
                     <Col>
-                        <Button
-                          key="remove"
-                          disabled={
-                            !removeItems ||
-                            (required && fields.length === 1 && index === 0)
-                          }
-                          {...options.removeButtonProps}
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            remove(field.name)
-                            removeItems?.(path, [index])()
-                          }}
-                        >
-                          {options.removeButtonProps?.children ?? "Delete"}
-                        </Button>
+                      <Button
+                        key="remove"
+                        disabled={
+                          !removeItems ||
+                          (required && fields.length === 1 && index === 0)
+                        }
+                        {...options.removeButtonProps}
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          remove(field.name)
+                          removeItems?.(path, [index])()
+                        }}
+                      >
+                        {options.removeButtonProps?.children ?? "Delete"}
+                      </Button>
                     </Col>
                   ) : null}
                 </Row>

--- a/src/stories/controls/PrimitiveArrayControl.stories.tsx
+++ b/src/stories/controls/PrimitiveArrayControl.stories.tsx
@@ -5,6 +5,7 @@ import {
   stringArrayControlJsonSchema,
   arrayControlUISchema,
   arrayControlTooltipUISchema,
+  arrayControlSortableUISchema,
 } from "../../testSchemas/arraySchema"
 
 const meta: Meta<typeof StorybookAntDJsonForm> = {
@@ -82,6 +83,26 @@ export const PrePopulatedArray: Story = {
       },
     } satisfies JSONSchema,
     uiSchema: arrayControlUISchema,
+    data: { assets: [1, 2, 3] },
+  },
+}
+
+export const SortableArray: Story = {
+  tags: ["autodocs"],
+  args: {
+    jsonSchema: {
+      type: "object",
+      properties: {
+        assets: {
+          type: "array",
+          items: {
+            type: "number",
+          },
+        },
+      },
+      required: ["assets"],
+    } satisfies JSONSchema,
+    uiSchema: arrayControlSortableUISchema,
     data: { assets: [1, 2, 3] },
   },
 }

--- a/src/stories/controls/PrimitiveArrayControl.stories.tsx
+++ b/src/stories/controls/PrimitiveArrayControl.stories.tsx
@@ -7,6 +7,7 @@ import {
   arrayControlTooltipUISchema,
   arrayControlSortableUISchema,
   arrayControlUISchemaWithIcons,
+  arrayControlSortableWithIconsUISchema,
 } from "../../testSchemas/arraySchema"
 
 const meta: Meta<typeof StorybookAntDJsonForm> = {
@@ -104,6 +105,26 @@ export const SortableArray: Story = {
       required: ["assets"],
     } satisfies JSONSchema,
     uiSchema: arrayControlSortableUISchema,
+    data: { assets: [1, 2, 3] },
+  },
+}
+
+export const SortableWithIconsArray: Story = {
+  tags: ["autodocs"],
+  args: {
+    jsonSchema: {
+      type: "object",
+      properties: {
+        assets: {
+          type: "array",
+          items: {
+            type: "number",
+          },
+        },
+      },
+      required: ["assets"],
+    } satisfies JSONSchema,
+    uiSchema: arrayControlSortableWithIconsUISchema,
     data: { assets: [1, 2, 3] },
   },
 }

--- a/src/stories/controls/PrimitiveArrayControl.stories.tsx
+++ b/src/stories/controls/PrimitiveArrayControl.stories.tsx
@@ -6,6 +6,7 @@ import {
   arrayControlUISchema,
   arrayControlTooltipUISchema,
   arrayControlSortableUISchema,
+  arrayControlUISchemaWithIcons,
 } from "../../testSchemas/arraySchema"
 
 const meta: Meta<typeof StorybookAntDJsonForm> = {
@@ -103,6 +104,26 @@ export const SortableArray: Story = {
       required: ["assets"],
     } satisfies JSONSchema,
     uiSchema: arrayControlSortableUISchema,
+    data: { assets: [1, 2, 3] },
+  },
+}
+
+export const WithIconsArray: Story = {
+  tags: ["autodocs"],
+  args: {
+    jsonSchema: {
+      type: "object",
+      properties: {
+        assets: {
+          type: "array",
+          items: {
+            type: "number",
+          },
+        },
+      },
+      required: ["assets"],
+    } satisfies JSONSchema,
+    uiSchema: arrayControlUISchemaWithIcons,
     data: { assets: [1, 2, 3] },
   },
 }

--- a/src/testSchemas/arraySchema.tsx
+++ b/src/testSchemas/arraySchema.tsx
@@ -14,7 +14,7 @@ export const arrayControlUISchema = {
       scope: "#/properties/assets",
       options: {
         showSortButtons: true,
-      }
+      },
     },
   ],
 } satisfies UISchema<typeof objectArrayControlJsonSchema>

--- a/src/testSchemas/arraySchema.tsx
+++ b/src/testSchemas/arraySchema.tsx
@@ -29,13 +29,26 @@ export const arrayControlSortableUISchema = {
       scope: "#/properties/assets",
       options: {
         showSortButtons: true,
+      },
+    },
+  ],
+} satisfies UISchema<typeof objectArrayControlJsonSchema>
+
+export const arrayControlSortableWithIconsUISchema = {
+  type: "VerticalLayout",
+  elements: [
+    {
+      type: "Control",
+      scope: "#/properties/assets",
+      options: {
+        showSortButtons: true,
         moveUpButtonProps: {
           icon: <ArrowUpOutlined />,
-          onClick: () => {}, // User should be unable to override the onClick event
+          onClick: () => {}, // Testing to verify this isn't called because the user should be unable to override the onClick event
         },
         moveDownButtonProps: {
           icon: <ArrowDownOutlined />,
-          onClick: () => {}, // User should be unable to override the onClick event
+          onClick: () => {}, // Testing to verify this isn't called because the user should be unable to override the onClick event
         },
       },
     },

--- a/src/testSchemas/arraySchema.tsx
+++ b/src/testSchemas/arraySchema.tsx
@@ -10,8 +10,11 @@ export const arrayControlUISchema = {
   type: "VerticalLayout",
   elements: [
     {
-      scope: "#/properties/assets",
       type: "Control",
+      scope: "#/properties/assets",
+      options: {
+        showSortButtons: true,
+      }
     },
   ],
 } satisfies UISchema<typeof objectArrayControlJsonSchema>

--- a/src/testSchemas/arraySchema.tsx
+++ b/src/testSchemas/arraySchema.tsx
@@ -1,6 +1,11 @@
 import { JSONSchema } from "json-schema-to-ts"
 import { ControlUISchema, UISchema } from "../ui-schema"
-import { PlusCircleTwoTone, DeleteOutlined } from "@ant-design/icons"
+import {
+  PlusCircleTwoTone,
+  DeleteOutlined,
+  ArrowUpOutlined,
+  ArrowDownOutlined,
+} from "@ant-design/icons"
 import {
   JsonFormsUISchemaRegistryEntry,
   UISchemaElement,
@@ -24,6 +29,14 @@ export const arrayControlSortableUISchema = {
       scope: "#/properties/assets",
       options: {
         showSortButtons: true,
+        moveUpButtonProps: {
+          icon: <ArrowUpOutlined />,
+          onClick: () => {}, // User should be unable to override the onClick event
+        },
+        moveDownButtonProps: {
+          icon: <ArrowDownOutlined />,
+          onClick: () => {}, // User should be unable to override the onClick event
+        },
       },
     },
   ],

--- a/src/testSchemas/arraySchema.tsx
+++ b/src/testSchemas/arraySchema.tsx
@@ -12,6 +12,16 @@ export const arrayControlUISchema = {
     {
       type: "Control",
       scope: "#/properties/assets",
+    },
+  ],
+} satisfies UISchema<typeof objectArrayControlJsonSchema>
+
+export const arrayControlSortableUISchema = {
+  type: "VerticalLayout",
+  elements: [
+    {
+      type: "Control",
+      scope: "#/properties/assets",
       options: {
         showSortButtons: true,
       },

--- a/src/ui-schema.ts
+++ b/src/ui-schema.ts
@@ -310,6 +310,8 @@ export type ArrayControlOptions = {
   removeButtonProps?: ButtonProps
   addButtonLocation?: AddButtonLocation
   showSortButtons?: boolean
+  moveUpButtonProps?: ButtonProps
+  moveDownButtonProps?: ButtonProps
 }
 
 export type NumericControlOptions = {

--- a/src/ui-schema.ts
+++ b/src/ui-schema.ts
@@ -309,6 +309,7 @@ export type ArrayControlOptions = {
   addButtonProps?: ButtonProps
   removeButtonProps?: ButtonProps
   addButtonLocation?: AddButtonLocation
+  showSortButtons?: boolean
 }
 
 export type NumericControlOptions = {


### PR DESCRIPTION
Allows primitive arrays to be sortable by setting `showSortButtons: true` in `arraySchema.tsx` Passing button props is optional and will display AntD's up and down arrow icons by default.

Default view
<img width="501" alt="image" src="https://github.com/user-attachments/assets/60f4fbd2-5dbc-4447-957e-efd565ff9314">

With icons provided by UISchema
<img width="482" alt="image" src="https://github.com/user-attachments/assets/34a875b7-51b3-4057-a50d-a958d1fbee67">

