### PR TITLE
fix checkbox visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ npm install @great-expectations/jsonforms-antd-renderers
 
 ### Using AntD Renderers
 
-In order to use this package, you need to import the renderer registry entries from this package and provide them to the `@jsonforms/react` `JsonForms` component:
+In order to use this package you need to import the renderer registry entries from this package and provide them to the `@jsonforms/react` `JsonForms` component:
 
 ```tsx
 import { JsonForms } from "@jsonforms/react"

--- a/src/controls/BooleanControl.tsx
+++ b/src/controls/BooleanControl.tsx
@@ -19,6 +19,8 @@ export function BooleanControl({
   config,
   description,
 }: ControlProps) {
+  if (!visible) return null
+
   const isValid = errors.length === 0
   const appliedUiSchemaOptions = {
     ...(config as Record<string, unknown>),


### PR DESCRIPTION
We're passing `visibility` as a prop into the BooleanControl component but not doing anything with it as relates to visibility of the rendered checkbox. This leads to unexpected behaviors when modifying visibility rules in downstream applications.

This PR adds the same `props.visible` check that's seen in other control elements.