### PR TITLE
fix (NumericControl, EnumControl): remove explicit col spans

### DIFF
--- a/src/controls/EnumControl.tsx
+++ b/src/controls/EnumControl.tsx
@@ -97,7 +97,7 @@ export const EnumControl = (props: ControlProps) => {
       validateTrigger={["onBlur"]}
       {...formItemProps}
     >
-      <Col span={18}>{selector}</Col>
+      <Col>{selector}</Col>
     </Form.Item>
   )
 }

--- a/src/controls/NumericControl.tsx
+++ b/src/controls/NumericControl.tsx
@@ -33,7 +33,7 @@ export const NumericControl = (props: ControlProps) => {
       validateTrigger={["onBlur"]}
       {...formItemProps}
     >
-      <Col span={18}>{InputNumber({ ...props })}</Col>
+      <Col>{InputNumber({ ...props })}</Col>
     </Form.Item>
   )
 }


### PR DESCRIPTION
The explicitly defined col spans in NumericControl and EnumControl make it difficult (or impossible) to predictably style these components in downstream applications.

These can now also be set declaratively via the UI Schema's layoutProps:columns.