### PR TITLE
fix(VerticalLayout): remove div element causing flex issues

### DIFF
--- a/src/layouts/HorizontalLayout.test.tsx
+++ b/src/layouts/HorizontalLayout.test.tsx
@@ -1,4 +1,4 @@
-import { test } from "vitest"
+import { test, expect } from "vitest"
 import { screen } from "@testing-library/react"
 import { render } from "../common/test-render"
 
@@ -6,6 +6,7 @@ import {
   numericMagnitudeSchema,
   numericHorizontalUISchema,
 } from "../testSchemas/numericSchema"
+import { HORIZONTAL_LAYOUT_FORM_TEST_ID } from "./HorizontalLayout"
 
 test("Horizontal layout renders", async () => {
   render({
@@ -13,4 +14,8 @@ test("Horizontal layout renders", async () => {
     uischema: numericHorizontalUISchema,
   })
   await screen.findByRole("spinbutton")
+  // since we are wrapped in a form no wrapper element should be introduced
+  expect(
+    screen.queryByTestId(HORIZONTAL_LAYOUT_FORM_TEST_ID),
+  ).not.toBeInTheDocument()
 })

--- a/src/layouts/HorizontalLayout.tsx
+++ b/src/layouts/HorizontalLayout.tsx
@@ -5,6 +5,8 @@ import { HorizontalLayoutUISchema } from "../ui-schema"
 import { Form, Row } from "antd"
 import { withJsonFormsLayoutProps } from "@jsonforms/react"
 
+export const HORIZONTAL_LAYOUT_FORM_TEST_ID = "horizontal-layout-form"
+
 export function HorizontalLayout({
   uischema,
   schema,
@@ -25,7 +27,11 @@ export function HorizontalLayout({
   }
   const form = Form.useFormInstance()
   return (
-    <Form component={form ? false : "form"} form={form}>
+    <Form
+      data-testid={HORIZONTAL_LAYOUT_FORM_TEST_ID}
+      component={form ? false : "form"}
+      form={form}
+    >
       {!isEmpty(groupLayout.label) && groupLayout.label}
       <Row justify="space-between" gutter={12} align="middle">
         <AntDLayout

--- a/src/layouts/VerticalLayout.test.tsx
+++ b/src/layouts/VerticalLayout.test.tsx
@@ -1,4 +1,4 @@
-import { test } from "vitest"
+import { test, expect } from "vitest"
 import { screen } from "@testing-library/react"
 import { render } from "../common/test-render"
 
@@ -6,6 +6,7 @@ import {
   numericMagnitudeSchema,
   numericVerticalUISchema,
 } from "../testSchemas/numericSchema"
+import { VERTICAL_LAYOUT_FORM_TEST_ID } from "./VerticalLayout"
 
 test("Vertical layout renders", async () => {
   render({
@@ -13,4 +14,9 @@ test("Vertical layout renders", async () => {
     uischema: numericVerticalUISchema,
   })
   await screen.findByRole("spinbutton")
+
+  // since we are wrapped in a form no wrapper element should be introduced
+  expect(
+    screen.queryByTestId(VERTICAL_LAYOUT_FORM_TEST_ID),
+  ).not.toBeInTheDocument()
 })

--- a/src/layouts/VerticalLayout.tsx
+++ b/src/layouts/VerticalLayout.tsx
@@ -1,4 +1,4 @@
-import { LayoutProps, GroupLayout } from "@jsonforms/core"
+import { LayoutProps } from "@jsonforms/core"
 import { AntDLayout, AntDLayoutProps } from "./LayoutRenderer"
 import { Form } from "antd"
 import { VerticalLayoutUISchema } from "../ui-schema"
@@ -13,10 +13,9 @@ export function VerticalLayout({
   renderers,
   cells,
 }: LayoutProps) {
-  const verticalLayout = uischema as VerticalLayoutUISchema<unknown>
-  const groupLayout = uischema as GroupLayout
+  const { elements } = uischema as VerticalLayoutUISchema<unknown>
   const childProps: AntDLayoutProps = {
-    elements: verticalLayout.elements,
+    elements,
     schema,
     path,
     enabled,
@@ -25,9 +24,6 @@ export function VerticalLayout({
   const form = Form.useFormInstance()
   return (
     <Form component={form ? false : "form"} scrollToFirstError form={form}>
-      {!!groupLayout.label && (
-        <div>{groupLayout.label}</div> // this was SubtitleSemiBold
-      )}
       <AntDLayout {...childProps} renderers={renderers} cells={cells} />
     </Form>
   )

--- a/src/layouts/VerticalLayout.tsx
+++ b/src/layouts/VerticalLayout.tsx
@@ -1,6 +1,6 @@
 import { LayoutProps, GroupLayout } from "@jsonforms/core"
 import { AntDLayout, AntDLayoutProps } from "./LayoutRenderer"
-import { Form, FormInstance, FormProps } from "antd"
+import { Form } from "antd"
 import { VerticalLayoutUISchema } from "../ui-schema"
 import { withJsonFormsLayoutProps } from "@jsonforms/react"
 
@@ -24,20 +24,13 @@ export function VerticalLayout({
   }
   const form = Form.useFormInstance()
   return (
-    <Form {...getFormLayoutOptions(form)} form={form}>
-      {!groupLayout.label && (
+    <Form component={form ? false : "form"} scrollToFirstError form={form}>
+      {!!groupLayout.label && (
         <div>{groupLayout.label}</div> // this was SubtitleSemiBold
       )}
       <AntDLayout {...childProps} renderers={renderers} cells={cells} />
     </Form>
   )
-}
-
-function getFormLayoutOptions(form: FormInstance): Partial<FormProps> {
-  return {
-    scrollToFirstError: true,
-    component: form ? "div" : "form",
-  }
 }
 
 export const VerticalLayoutRenderer = withJsonFormsLayoutProps(VerticalLayout)

--- a/src/layouts/VerticalLayout.tsx
+++ b/src/layouts/VerticalLayout.tsx
@@ -4,6 +4,8 @@ import { Form } from "antd"
 import { VerticalLayoutUISchema } from "../ui-schema"
 import { withJsonFormsLayoutProps } from "@jsonforms/react"
 
+export const VERTICAL_LAYOUT_FORM_TEST_ID = "vertical-layout-form"
+
 export function VerticalLayout({
   uischema,
   schema,
@@ -23,7 +25,12 @@ export function VerticalLayout({
   }
   const form = Form.useFormInstance()
   return (
-    <Form component={form ? false : "form"} scrollToFirstError form={form}>
+    <Form
+      data-testid={VERTICAL_LAYOUT_FORM_TEST_ID}
+      component={form ? false : "form"}
+      scrollToFirstError
+      form={form}
+    >
       <AntDLayout {...childProps} renderers={renderers} cells={cells} />
     </Form>
   )


### PR DESCRIPTION
Unlike the `HorzontalLayout` the `VerticalLayout` was submitting `div` as the component prop to the antd `Form` component.  This causes an issue with container heights, overflow and margin collapse when attempting to use the `vertical` layout prop in either forms or form items.


For instance, if one updates the [StorybookAntDJsonForm](src/common/StorybookAntDJsonForm.tsx) like so:
```tsx
...
 return (
 +   <Form form={form} layout="vertical">
      <AntDJsonForm<typeof jsonSchema>
        uiSchema={uiSchema}
        jsonSchema={jsonSchema}
   ....
```

The resulting issues can be seen in all stories featuring the `VerticalLayout` renderer:
<img width="895" alt="Screenshot 2024-10-03 at 12 31 51 PM" src="https://github.com/user-attachments/assets/7735ee8d-3672-47a3-ab0d-352bf3251426">
<img width="894" alt="Screenshot 2024-10-03 at 12 32 18 PM" src="https://github.com/user-attachments/assets/37494a6b-2b89-48d5-bc5e-b26b6bf4ed83">

however, the same issue is not present in the `HorizontalLayout`

<img width="1025" alt="Screenshot 2024-10-03 at 12 33 16 PM" src="https://github.com/user-attachments/assets/59ecc24a-d797-4c0e-955f-b62f9255b935">


After investigation this appears to have been caused by the `component` prop being supplied to `Form` in the Vertical layout being a div rather than `false` as it is in `HorizontalLayout`.   This update brings parity to the two components in terms of dom structure expectations and fixes the issues with vertical forms.

<img width="1023" alt="Screenshot 2024-10-03 at 12 36 36 PM" src="https://github.com/user-attachments/assets/e93da474-1aa4-48fe-aafd-b41c59339bfd">

