### PR TITLE
feat(DateTimeControl): Add DateTimeControl to default renderers

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@jsonforms/core": "^3.3.0",
     "@jsonforms/react": "^3.3.0",
     "antd": "^5.14.0",
+    "dayjs": "^1",
     "react": "^17 || ^18"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  dayjs:
+    specifier: ^1
+    version: 1.11.13
   lodash.isempty:
     specifier: ^4.4.0
     version: 4.4.0
@@ -6051,7 +6054,6 @@ packages:
 
   /dayjs@1.11.13:
     resolution: {integrity: sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==}
-    dev: true
 
   /debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}

--- a/src/antd/InputNumber.tsx
+++ b/src/antd/InputNumber.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useCallback } from "react"
+import { useCallback } from "react"
 import { ControlProps, RendererProps } from "@jsonforms/core"
 import { InputNumber as AntdInputNumber } from "antd"
 import { NumericControlOptions } from "../ui-schema"
@@ -9,7 +9,6 @@ import {
   percentageStringToDecimal,
 } from "../controls/utils"
 
-type InputNumber = ReactElement<typeof AntdInputNumber>
 type AntdInputNumberProps = React.ComponentProps<typeof AntdInputNumber>
 type InputNumberProps = AntdInputNumberProps & RendererProps & ControlProps
 

--- a/src/common/schema-derived-types.ts
+++ b/src/common/schema-derived-types.ts
@@ -6,6 +6,7 @@ import {
   NumericControlOptions,
   OneOfControlOptions,
   TextControlOptions,
+  DateTimeControlOptions,
   UISchema,
 } from ".."
 
@@ -21,11 +22,13 @@ type JsonSchemaTypeToControlOptions<
   // K extends keyof T & string,
 > = T extends { enum: unknown }
   ? EnumControlOptions
-  : T extends { type: infer U }
+  : T extends { type: infer U; format?: infer F }
     ? U extends "object" // ObjectControlOptions goes here
       ? unknown
       : U extends "string"
-        ? TextControlOptions
+        ? F extends "date-time"
+          ? DateTimeControlOptions
+          : TextControlOptions
         : U extends "number" | "integer"
           ? NumericControlOptions
           : U extends "array"

--- a/src/controls/DateTimeControl.test.tsx
+++ b/src/controls/DateTimeControl.test.tsx
@@ -1,0 +1,133 @@
+import { test, expect } from "vitest"
+import { screen, waitFor } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
+
+import { render } from "../common/test-render"
+import { dateTimeSchema } from "../testSchemas/dateTimeSchema"
+import { UISchema } from "../ui-schema"
+
+const EXAMPLE_DATESTRING = "2021-08-09 12:34:56"
+const USER_DATESTRING = EXAMPLE_DATESTRING.replace(" ", "")
+const TITLE = dateTimeSchema.properties.dateTime.title
+
+test("renders the date that the user selects", async () => {
+  render({
+    schema: dateTimeSchema,
+  })
+  const input = await screen.findByLabelText(TITLE)
+  await userEvent.type(input, USER_DATESTRING)
+
+  await waitFor(() => expect(input).toHaveValue(EXAMPLE_DATESTRING))
+})
+
+test("renders default date when present", async () => {
+  render({
+    schema: {
+      ...dateTimeSchema,
+      properties: {
+        dateTime: {
+          ...dateTimeSchema.properties.dateTime,
+          default: EXAMPLE_DATESTRING,
+        },
+      },
+    },
+  })
+  const input = await screen.findByLabelText(TITLE)
+  expect(input).toHaveValue(EXAMPLE_DATESTRING)
+})
+
+test("updates jsonforms data as expected", async () => {
+  let data: Record<string, unknown> = {}
+  render({
+    schema: dateTimeSchema,
+    data,
+    onChange: (result) => {
+      data = result.data as Record<string, unknown>
+    },
+  })
+  const input = await screen.findByLabelText(TITLE)
+  await userEvent.type(input, USER_DATESTRING)
+  await userEvent.click(screen.getByText("Submit"))
+  await waitFor(() => {
+    expect(data).toEqual({
+      dateTime: EXAMPLE_DATESTRING,
+    })
+  })
+})
+
+test("renders required message if no value and interaction", async () => {
+  render({
+    schema: {
+      ...dateTimeSchema,
+      required: ["dateTime"],
+    },
+  })
+  const input = await screen.findByLabelText(TITLE)
+  await userEvent.clear(input)
+  await userEvent.tab()
+  await screen.findByText(`${TITLE} is required`)
+})
+
+test(" does not show required message if not requried", async () => {
+  render({
+    schema: dateTimeSchema,
+  })
+  const input = await screen.findByLabelText(TITLE)
+  await userEvent.clear(input)
+  await userEvent.tab()
+  await waitFor(() => {
+    expect(screen.queryByText(`${TITLE} is required`)).toBeNull()
+  })
+})
+
+test("showTime option should have visible 'now' button", async () => {
+  const uischema = {
+    type: "VerticalLayout",
+    elements: [
+      {
+        type: "Control",
+        scope: "#/properties/dateTime",
+        label: "Date Time",
+        options: {
+          showTime: true,
+        },
+      },
+    ],
+  } satisfies UISchema<typeof dateTimeSchema>
+
+  render({
+    schema: dateTimeSchema,
+    uischema,
+  })
+  const input = await screen.findByLabelText(TITLE)
+  await userEvent.click(input)
+  await screen.findByText("Now")
+})
+
+test("renders default props if invalid props are submitted", async () => {
+  const uischema = {
+    type: "VerticalLayout",
+    elements: [
+      {
+        type: "Control",
+        scope: "#/properties/dateTime",
+        label: "Date Time",
+        options: {
+          /** @ts-expect-error to test the fail route we need to provide an invalid prop */
+          foo: "bar",
+          showTime: true,
+        },
+      },
+    ],
+  } satisfies UISchema<typeof dateTimeSchema>
+
+  render({
+    schema: dateTimeSchema,
+    uischema,
+  })
+  const input2 = await screen.findByLabelText(TITLE)
+  await userEvent.click(input2)
+  // instead of "now" should see "today"
+  // since our default doesn't show time
+  await screen.findByText("Today")
+})

--- a/src/controls/DateTimeControl.tsx
+++ b/src/controls/DateTimeControl.tsx
@@ -1,0 +1,75 @@
+import { memo } from "react"
+import type { ControlProps as JSFControlProps } from "@jsonforms/core"
+import { withJsonFormsControlProps } from "@jsonforms/react"
+import { DatePicker, type DatePickerProps, Form } from "antd"
+import type { Rule } from "antd/es/form"
+import dayjs from "dayjs"
+
+import {
+  ControlUISchema,
+  DateTimeControlOptions,
+  isDateTimeControlOptions,
+} from "../ui-schema"
+
+type ControlProps = Omit<JSFControlProps, "uischema"> & {
+  uischema: ControlUISchema<unknown> | JSFControlProps["uischema"]
+}
+// initialize once
+const DEFAULT_PROPS: DateTimeControlOptions = {
+  format: { format: "YYYY-MM-DD HH:mm:ss", type: "mask" },
+} as const
+
+function getProps(options: unknown): DateTimeControlOptions {
+  if (isDateTimeControlOptions(options)) {
+    return options
+  }
+  return DEFAULT_PROPS
+}
+
+export function DateTimeControl({
+  handleChange,
+  path,
+  label,
+  id,
+  required,
+  schema,
+  uischema,
+  visible,
+}: ControlProps) {
+  if (!visible) return null
+
+  const initialValue =
+    typeof schema.default === "string" ? dayjs(schema.default) : undefined
+
+  const rules: Rule[] = [{ required, message: `${label} is required` }]
+
+  const formItemProps =
+    "formItemProps" in uischema ? uischema.formItemProps : {}
+
+  const onChange: DatePickerProps["onChange"] = (_dateObj, dateString) => {
+    handleChange(path, dateString)
+  }
+
+  const options = getProps(uischema.options)
+
+  return (
+    <Form.Item
+      label={label}
+      id={id}
+      name={path}
+      required={required}
+      validateTrigger={["onBlur"]}
+      rules={rules}
+      initialValue={initialValue}
+      {...formItemProps}
+    >
+      <DatePicker
+        format={DEFAULT_PROPS.format}
+        onChange={onChange}
+        {...options}
+      />
+    </Form.Item>
+  )
+}
+
+export const DateTimeRenderer = withJsonFormsControlProps(memo(DateTimeControl))

--- a/src/renderer-registry-entries.ts
+++ b/src/renderer-registry-entries.ts
@@ -21,6 +21,7 @@ import {
   isOneOfControl,
   isAnyOfControl,
   isEnumControl,
+  isDateTimeControl,
 } from "@jsonforms/core"
 import { withJsonFormsCellProps } from "@jsonforms/react"
 
@@ -39,6 +40,7 @@ import { PrimitiveArrayRenderer } from "./controls/PrimitiveArrayControl"
 import { OneOfRenderer } from "./controls/combinators/OneOfControl"
 import { AnyOfRenderer } from "./controls/combinators/AnyOfControl"
 import { EnumRenderer } from "./controls/EnumControl"
+import { DateTimeRenderer } from "./controls/DateTimeControl"
 
 // Ordered from lowest rank to highest rank. Higher rank renderers will be preferred over lower rank renderers.
 export const rendererRegistryEntries: JsonFormsRendererRegistryEntry[] = [
@@ -112,6 +114,10 @@ export const rendererRegistryEntries: JsonFormsRendererRegistryEntry[] = [
   {
     tester: rankWith(30, isPrimitiveArrayControl),
     renderer: PrimitiveArrayRenderer,
+  },
+  {
+    tester: rankWith(3, isDateTimeControl),
+    renderer: DateTimeRenderer,
   },
 ]
 

--- a/src/stories/controls/DateTimeControl.stories.tsx
+++ b/src/stories/controls/DateTimeControl.stories.tsx
@@ -1,0 +1,65 @@
+import { Meta, StoryObj } from "@storybook/react"
+import { StorybookAntDJsonForm } from "../../common/StorybookAntDJsonForm"
+import {
+  dateTimeSchema,
+  dateTimeShowTimeUISchema,
+  dateTimeUISchema,
+  dateTimeOverrideDefaultFormatUISchema,
+  dateTimeShowMillisecondHideNowUISchema,
+  dateTimeDefaultValueSchema,
+} from "../../testSchemas/dateTimeSchema"
+
+const meta: Meta<typeof StorybookAntDJsonForm> = {
+  title: "Control/DateTime",
+  component: StorybookAntDJsonForm,
+  tags: ["autodocs"],
+  args: {
+    jsonSchema: dateTimeSchema,
+    uiSchema: dateTimeUISchema,
+  },
+  argTypes: {},
+}
+
+export default meta
+
+type Story = StoryObj<typeof StorybookAntDJsonForm>
+
+export const RequiredDatetime: Story = {
+  tags: ["autodocs"],
+  args: {
+    jsonSchema: dateTimeSchema,
+    uiSchema: dateTimeUISchema,
+  },
+}
+
+export const ShowTime: Story = {
+  tags: ["autodocs"],
+  args: {
+    jsonSchema: dateTimeSchema,
+    uiSchema: dateTimeShowTimeUISchema,
+  },
+}
+
+export const ShowMillisecondHideNow: Story = {
+  tags: ["autodocs"],
+  args: {
+    jsonSchema: dateTimeSchema,
+    uiSchema: dateTimeShowMillisecondHideNowUISchema,
+  },
+}
+
+export const OverrideDefaultFormat: Story = {
+  tags: ["autodocs"],
+  args: {
+    jsonSchema: dateTimeSchema,
+    uiSchema: dateTimeOverrideDefaultFormatUISchema,
+  },
+}
+
+export const DefaultValue: Story = {
+  tags: ["autodocs"],
+  args: {
+    jsonSchema: dateTimeDefaultValueSchema,
+    uiSchema: dateTimeUISchema,
+  },
+}

--- a/src/testSchemas/dateTimeSchema.ts
+++ b/src/testSchemas/dateTimeSchema.ts
@@ -1,0 +1,83 @@
+import { JSONSchema } from "json-schema-to-ts"
+import { UISchema } from "../ui-schema"
+
+export const dateTimeSchema = {
+  type: "object",
+  properties: {
+    dateTime: {
+      title: "Date Time",
+      type: "string",
+      format: "date-time",
+    },
+  },
+  required: ["dateTime"],
+} as const satisfies JSONSchema
+
+export const dateTimeDefaultValueSchema = {
+  type: "object",
+  properties: {
+    dateTime: {
+      title: "Date Time",
+      type: "string",
+      format: "date-time",
+      default: "2021-08-09 12:34:56",
+    },
+  },
+} as const satisfies JSONSchema
+
+export const dateTimeUISchema = {
+  type: "VerticalLayout",
+  elements: [
+    {
+      type: "Control",
+      scope: "#/properties/dateTime",
+      label: "Date Time",
+    },
+  ],
+} satisfies UISchema<typeof dateTimeSchema>
+
+export const dateTimeShowTimeUISchema = {
+  type: "VerticalLayout",
+  elements: [
+    {
+      type: "Control",
+      scope: "#/properties/dateTime",
+      label: "Date Time",
+      options: {
+        showTime: true,
+      },
+    },
+  ],
+} satisfies UISchema<typeof dateTimeSchema>
+
+export const dateTimeShowMillisecondHideNowUISchema = {
+  type: "VerticalLayout",
+  elements: [
+    {
+      type: "Control",
+      scope: "#/properties/dateTime",
+      label: "Date Time",
+      options: {
+        showTime: true,
+        showMillisecond: true,
+        showNow: false,
+      },
+    },
+  ],
+} satisfies UISchema<typeof dateTimeSchema>
+
+export const dateTimeOverrideDefaultFormatUISchema = {
+  type: "VerticalLayout",
+  elements: [
+    {
+      type: "Control",
+      scope: "#/properties/dateTime",
+      label: "Date Time",
+      options: {
+        format: {
+          format: "MM/DD",
+        },
+      },
+    },
+  ],
+} satisfies UISchema<typeof dateTimeSchema>

--- a/src/ui-schema.ts
+++ b/src/ui-schema.ts
@@ -7,6 +7,7 @@ import type {
   FormItemProps,
   InputNumberProps,
   InputProps,
+  DatePickerProps,
 } from "antd"
 import type { TextAreaProps } from "antd/es/input"
 import type { RuleObject as AntDRule } from "antd/es/form"
@@ -190,6 +191,55 @@ export type TextControlOptions = {
       inputProps?: InputProps
     }
 )
+
+/**
+ * The input props of the AntD DatePicker component that we want to
+ * expose to api consumers through schema options.  Full list of props
+ * can be found in [this section](https://ant.design/components/date-picker#datepicker)
+ * of the antd docs.
+ */
+export const allowedDateTimePropKeys: (keyof DatePickerProps)[] = [
+  "id",
+  "is",
+  "alt",
+  "size",
+  "width",
+  "style",
+  "format",
+  "height",
+  "title",
+  "presets",
+  "showNow",
+  "showHour",
+  "showTime",
+  "showWeek",
+  "showMinute",
+  "showSecond",
+  "showMillisecond",
+] as const
+
+export type DateTimeControlOptions = Pick<
+  DatePickerProps,
+  (typeof allowedDateTimePropKeys)[number]
+>
+
+export function isDateTimeControlOptions(
+  options: unknown,
+): options is DateTimeControlOptions {
+  if (typeof options !== "object" || options == null) {
+    return false
+  }
+
+  for (const key of Object.keys(options)) {
+    if (
+      !allowedDateTimePropKeys.includes(key as keyof DateTimeControlOptions)
+    ) {
+      return false
+    }
+  }
+
+  return true
+}
 
 /**
  * A control element. The scope property of the control determines


### PR DESCRIPTION
- add a DateTimeControl that looks for string fields with the format of `date-time` with a priorty of `3`.
- expose some useful AntD DatePicker props via the `uiSchema.options` interface typed via updating the existing option type helper.
- add storybook stories showing basic usage
- add tests covering standard behavior.

