### PR TITLE
fix(DateTimeControl): use data if present

### DIFF
--- a/src/stories/controls/DateTimeControl.stories.tsx
+++ b/src/stories/controls/DateTimeControl.stories.tsx
@@ -63,3 +63,14 @@ export const DefaultValue: Story = {
     uiSchema: dateTimeUISchema,
   },
 }
+
+export const ExistingValue: Story = {
+  tags: ["autodocs"],
+  args: {
+    jsonSchema: dateTimeSchema,
+    uiSchema: dateTimeUISchema,
+    data: {
+      dateTime: "1999-12-31T23:59:59.999Z",
+    },
+  },
+}


### PR DESCRIPTION
Currently, If a form is rendered with and pre-populated values in `data` the DatePicker does not get set with the value from the form.

This fixes that behavior and adds a story and test to prevent regressions.