### PR TITLE
fix(DefaultExport): export InputNumber and Slider to allow customization

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,3 +18,8 @@ export { TextControl } from "./controls/TextControl"
 export { DateTimeControl } from "./controls/DateTimeControl"
 export { UnknownControl } from "./controls/UnknownControl"
 export { VerticalLayout } from "./layouts/VerticalLayout"
+
+// Re-export some custom antd components to allow for
+// external customization without losing functionality
+export { InputNumber } from "./antd/InputNumber"
+export { Slider } from "./antd/Slider"


### PR DESCRIPTION
The `NumericSliderControl` component uses both `InputNumber` and `Slider` with fixed column values, but there may be cases where we want the Input/Slider to have different width properties.

The `NumericSliderControl` is easy enough to mask with a custom renderer in downstream codebases, but the functionality embedded within `InputNumber` and `Slider` is less so. This makes it possible to customize those components' layouts without mucking around too much with types & configs.