### PR TITLE
fix(NumericSliderControl): Fix slider not updating input box

### DIFF
--- a/src/antd/InputNumber.tsx
+++ b/src/antd/InputNumber.tsx
@@ -3,11 +3,11 @@ import { ControlProps, RendererProps } from "@jsonforms/core"
 import { InputNumber as AntdInputNumber } from "antd"
 import { NumericControlOptions } from "../ui-schema"
 import {
+  areStringNumbersEqual,
   coerceToInteger,
   coerceToNumber,
   decimalToPercentage,
   percentageStringToDecimal,
-  hasLeadingZero,
 } from "../controls/utils"
 
 type AntdInputNumberProps = React.ComponentProps<typeof AntdInputNumber>
@@ -79,8 +79,7 @@ export function InputNumber({
       if (
         value &&
         typeof incomingValue.current === "string" &&
-        hasLeadingZero(incomingValue.current) &&
-        !isNaN(parseFloat(incomingValue.current))
+        areStringNumbersEqual(incomingValue.current, value)
       ) {
         return incomingValue.current
       }

--- a/src/controls/utils.test.ts
+++ b/src/controls/utils.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest"
 import {
   decimalToPercentage,
   percentageStringToDecimal,
-  hasLeadingZero,
+  areStringNumbersEqual,
 } from "./utils"
 
 describe("percentageStringToDecimal", () => {
@@ -38,17 +38,24 @@ describe("decimalToPercentage", () => {
   )
 })
 
-describe("hasLeadingZero", () => {
+describe("areStringNumbersEqual", () => {
   test.each([
-    { value: "100", expected: false },
-    { value: "00", expected: true },
-    { value: "2", expected: false },
-    { value: "0", expected: false },
-    { value: "03", expected: true },
-  ])(
-    "returns $expected for input '$value'",
-    ({ value, expected }: { value: string; expected: boolean }) => {
-      expect(hasLeadingZero(value)).toBe(expected)
-    },
-  )
+    ["0", 0, true],
+    ["0", "0", true],
+    ["0000", 0, true],
+    ["0000", "00", true],
+    ["00567", 567, true],
+    ["00567", "567", true],
+    ["567", 567, true],
+    ["567", "567", true],
+    ["aaa", NaN, false],
+    ["NaN", NaN, false],
+    ["aaa", "aaa", false],
+    ["aaa", 0, false],
+    ["00567", "00568", false],
+    ["00567", 568, false],
+    ["567", 568, false],
+  ])("areStringNumbersEqual(%o, %o) -> %o", (a, b, expected) => {
+    expect(areStringNumbersEqual(a, b)).toBe(expected)
+  })
 })

--- a/src/controls/utils.ts
+++ b/src/controls/utils.ts
@@ -17,17 +17,15 @@ export const areStringNumbersEqual = (
   value: string | number,
 ): boolean => {
   /**
-   * Returns true if rawValue is a string that represents a number and is
-   * equal to value as a number.
+   * Returns true if both inputs represent numbers and are equal.
    */
-  // If either input is not a number return false
   const parsedRawValue = parseFloat(rawValue)
   const parsedValue = typeof value === "string" ? parseFloat(value) : value
-  if (isNaN(parsedRawValue) || isNaN(parsedValue)) {
-    return false
-  }
-  // If both parsed values are numbers, return true if they are equal
-  if (parsedRawValue === parsedValue) {
+  if (
+    !isNaN(parsedRawValue) &&
+    !isNaN(parsedValue) &&
+    parsedRawValue === parsedValue
+  ) {
     return true
   }
   return false

--- a/src/controls/utils.ts
+++ b/src/controls/utils.ts
@@ -21,10 +21,7 @@ export const areStringNumbersEqual = (
    */
   const parsedRawValue = parseFloat(rawValue)
   const parsedValue = typeof value === "string" ? parseFloat(value) : value
-  if (
-    !isNaN(parsedRawValue) &&
-    parsedRawValue === parsedValue
-  ) {
+  if (!isNaN(parsedRawValue) && parsedRawValue === parsedValue) {
     return true
   }
   return false

--- a/src/controls/utils.ts
+++ b/src/controls/utils.ts
@@ -19,6 +19,7 @@ export const areStringNumbersEqual = (
   /**
    * Returns true if both inputs represent numbers and are equal.
    */
+  // If a string is not parsable as a number, parseFloat will return NaN.
   const parsedRawValue = parseFloat(rawValue)
   const parsedValue = typeof value === "string" ? parseFloat(value) : value
   if (!isNaN(parsedRawValue) && parsedRawValue === parsedValue) {

--- a/src/controls/utils.ts
+++ b/src/controls/utils.ts
@@ -23,7 +23,6 @@ export const areStringNumbersEqual = (
   const parsedValue = typeof value === "string" ? parseFloat(value) : value
   if (
     !isNaN(parsedRawValue) &&
-    !isNaN(parsedValue) &&
     parsedRawValue === parsedValue
   ) {
     return true

--- a/src/controls/utils.ts
+++ b/src/controls/utils.ts
@@ -12,6 +12,23 @@ export const coerceToInteger = (value: number) => Math.round(value)
 
 export const coerceToNumber = (value: number) => Number(value)
 
-export const hasLeadingZero = (value?: string) =>
-  // The value 0 is just 0 and doesn't have leading 0s.
-  value && value.substring(0, 1) === "0" && value.length > 1
+export const areStringNumbersEqual = (
+  rawValue: string,
+  value: string | number,
+): boolean => {
+  /**
+   * Returns true if rawValue is a string that represents a number and is
+   * equal to value as a number.
+   */
+  // If either input is not a number return false
+  const parsedRawValue = parseFloat(rawValue)
+  const parsedValue = typeof value === "string" ? parseFloat(value) : value
+  if (isNaN(parsedRawValue) || isNaN(parsedValue)) {
+    return false
+  }
+  // If both parsed values are numbers, return true if they are equal
+  if (parsedRawValue === parsedValue) {
+    return true
+  }
+  return false
+}


### PR DESCRIPTION
Previously, if the numeric input box contains a value starting with "0" the slider no longer updates the numeric input box. This happened if the slider goes to zero. Or if the input box is updated directly and contains a leading "0"; for example, if you delete the 3 from 3000.

![slider](https://github.com/user-attachments/assets/4d22a5ab-f50f-4e10-b90a-f880c2258915)
