### PR TITLE
fix(EnumControl): validate onChange by default

### DIFF
--- a/src/controls/EnumControl.tsx
+++ b/src/controls/EnumControl.tsx
@@ -94,7 +94,6 @@ export const EnumControl = (props: ControlProps) => {
       required={props.required}
       initialValue={defaultValue}
       rules={rules}
-      validateTrigger={["onBlur"]}
       {...formItemProps}
     >
       <Col>{selector}</Col>


### PR DESCRIPTION
When selecting an enum value from the list, the `onBlur` validation runs without having updated to the selected value. This causes inline validation to fail until the user types into the search bar, selects via keyboard, and then tabs out of the field.