### PR TITLE
fix(EnumControl): more robust validation

### DIFF
--- a/src/controls/EnumControl.test.tsx
+++ b/src/controls/EnumControl.test.tsx
@@ -73,3 +73,206 @@ test("handles onChange event correctly", async () => {
     }),
   )
 })
+
+test("validates required field on form submission - dropdown", async () => {
+  render({
+    schema: enumProfessionSchema,
+    uischema: enumProfessionUISchema,
+    data: {},
+  })
+
+  // Click submit button to trigger validation
+  const submitButton = screen.getByRole("button", { name: "Submit" })
+  await userEvent.click(submitButton)
+
+  await waitFor(() => {
+    screen.getByText("Profession is required")
+  })
+})
+
+test("validates required field on form submission - radio", async () => {
+  render({
+    schema: enumProfessionSchema,
+    uischema: {
+      type: "VerticalLayout",
+      elements: [
+        {
+          type: "Control",
+          scope: "#/properties/profession",
+          options: { optionType: "radio" },
+        },
+      ],
+    },
+    data: {},
+  })
+
+  // Click submit button to trigger validation
+  const submitButton = screen.getByRole("button", { name: "Submit" })
+  await userEvent.click(submitButton)
+
+  await waitFor(() => {
+    screen.getByText("Profession is required")
+  })
+})
+
+test("clears validation error on valid selection - dropdown", async () => {
+  render({
+    schema: enumProfessionSchema,
+    uischema: enumProfessionUISchema,
+    data: {},
+  })
+
+  // First trigger validation error
+  const submitButton = screen.getByRole("button", { name: "Submit" })
+  await userEvent.click(submitButton)
+
+  await waitFor(() => {
+    screen.getByText("Profession is required")
+  })
+
+  // Now select a valid value
+  const combobox = screen.getByRole("combobox")
+  await userEvent.click(combobox)
+  await userEvent.click(screen.getByTitle("Software Engineer"))
+
+  // Try submitting again - should not show validation error
+  await userEvent.click(submitButton)
+
+  await waitFor(() => {
+    expect(screen.queryByText("Profession is required")).not.toBeInTheDocument()
+  })
+})
+
+test("clears validation error on valid selection - radio", async () => {
+  render({
+    schema: enumProfessionSchema,
+    uischema: {
+      type: "VerticalLayout",
+      elements: [
+        {
+          type: "Control",
+          scope: "#/properties/profession",
+          options: { optionType: "radio" },
+        },
+      ],
+    },
+    data: {},
+  })
+
+  // First trigger validation error
+  const submitButton = screen.getByRole("button", { name: "Submit" })
+  await userEvent.click(submitButton)
+
+  await waitFor(() => {
+    screen.getByText("Profession is required")
+  })
+
+  // Select a valid value by clicking the label instead of the radio input
+  await userEvent.click(screen.getByText("Software Engineer"))
+
+  // Try submitting again - should not show validation error
+  await userEvent.click(submitButton)
+
+  await waitFor(() => {
+    expect(screen.queryByText("Profession is required")).not.toBeInTheDocument()
+  })
+})
+
+test("validates on change for dropdown", async () => {
+  const onChange = vi.fn()
+  render({
+    schema: enumProfessionSchema,
+    uischema: enumProfessionUISchema,
+    data: {},
+    onChange,
+  })
+
+  const combobox = screen.getByRole("combobox")
+
+  // Select a value and verify onChange is called with no errors
+  await userEvent.click(combobox)
+  await userEvent.click(screen.getByTitle("Software Engineer"))
+
+  await waitFor(() => {
+    expect(onChange).toHaveBeenCalledWith({
+      data: { profession: "Software Engineer" },
+      errors: [],
+    })
+  })
+})
+
+test("validates on change for segmented control", async () => {
+  const onChange = vi.fn()
+  render({
+    schema: {
+      type: "object",
+      properties: {
+        size: {
+          title: "Size",
+          type: "string",
+          enum: ["S", "M", "L"],
+        },
+      },
+      required: ["size"],
+    },
+    uischema: {
+      type: "VerticalLayout",
+      elements: [
+        {
+          type: "Control",
+          scope: "#/properties/size",
+          options: { optionType: "segmented" },
+        },
+      ],
+    },
+    data: {},
+    onChange,
+  })
+
+  // Click on a segmented option - note that segmented starts with first option selected by default
+  // So we click a different option to see the change
+  const segmentedOption = screen.getByText("M")
+  await userEvent.click(segmentedOption)
+
+  await waitFor(() => {
+    expect(onChange).toHaveBeenCalledWith({
+      data: { size: "M" },
+      errors: [],
+    })
+  })
+})
+
+test("handles validation for segmented control on form submission", async () => {
+  render({
+    schema: {
+      type: "object",
+      properties: {
+        size: {
+          title: "Size",
+          type: "string",
+          enum: ["S", "M", "L"],
+        },
+      },
+      required: ["size"],
+    },
+    uischema: {
+      type: "VerticalLayout",
+      elements: [
+        {
+          type: "Control",
+          scope: "#/properties/size",
+          options: { optionType: "segmented" },
+        },
+      ],
+    },
+    data: {},
+  })
+
+  // Click submit button to trigger validation
+  const submitButton = screen.getByRole("button", { name: "Submit" })
+  await userEvent.click(submitButton)
+
+  await waitFor(() => {
+    screen.getByText("Size is required")
+  })
+})

--- a/src/controls/EnumControl.tsx
+++ b/src/controls/EnumControl.tsx
@@ -3,6 +3,7 @@ import { Form, Select, Segmented, Radio, Col } from "antd"
 import type { Rule } from "antd/es/form"
 import { EnumControlOptions, ControlUISchema } from "../ui-schema"
 import { withJsonFormsControlProps } from "@jsonforms/react"
+import { useEffect } from "react"
 
 type ControlProps = Omit<JSFControlProps, "uischema"> & {
   uischema: ControlUISchema<unknown> | JSFControlProps["uischema"]
@@ -14,7 +15,40 @@ const isStringOrNumberArray = (arr: unknown[]): boolean => {
   )
 }
 
+/**
+ * Creates an initial value setter for EnumControl
+ */
+function createEnumInitialValueSetter(
+  handleChange: (path: string, value: unknown) => void,
+  path: string,
+) {
+  return (value: unknown) => {
+    handleChange(path, value)
+    return value
+  }
+}
+
 export const EnumControl = (props: ControlProps) => {
+  const setInitialValue = createEnumInitialValueSetter(
+    props.handleChange,
+    props.path,
+  )
+  const form = Form.useFormInstance()
+
+  const defaultValue =
+    (props.data as unknown) ?? (props.schema.default as unknown)
+
+  useEffect(() => {
+    form.setFieldValue(props.path, setInitialValue(defaultValue))
+  }, [
+    props.data,
+    form,
+    props.path,
+    props.schema.default,
+    setInitialValue,
+    defaultValue,
+  ])
+
   if (!props.visible) return null
 
   const rules: Rule[] = [
@@ -23,9 +57,6 @@ export const EnumControl = (props: ControlProps) => {
 
   const formItemProps =
     "formItemProps" in props.uischema ? props.uischema.formItemProps : {}
-
-  const defaultValue =
-    (props.data as unknown) ?? (props.schema.default as unknown)
 
   const appliedUiSchemaOptions = props.uischema.options as EnumControlOptions
 
@@ -92,7 +123,6 @@ export const EnumControl = (props: ControlProps) => {
       id={props.id}
       name={props.path}
       required={props.required}
-      initialValue={defaultValue}
       rules={rules}
       {...formItemProps}
     >


### PR DESCRIPTION
Found some additional scenarios where the Enum dropdown would fail to validate, so this introduces some more robust validation handling, and follows a `useEffect` form state sync pattern used elsewhere.