### PR TITLE
fix: prevent webpack from tree-shaking renderer registry entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
   "files": [
     "lib/**/*"
   ],
+  "sideEffects": [
+    "./lib/cjs/renderer-registry-entries.js",
+    "./lib/esm/renderer-registry-entries.js"
+  ],
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "types": "./lib/cjs/index.d.ts",

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -3,8 +3,8 @@
   "compilerOptions": {
     "lib": ["ES2022", "DOM"],
     "target": "ES2022",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
     "outDir": "./lib/esm",
     "declarationDir": "./lib/esm"
   }


### PR DESCRIPTION
**Problem** 
The ESM build (`lib/esm/`) was incorrectly emitting CommonJS syntax, which breaks tree-shaking in bundlers like Webpack because CommonJS modules cannot be statically analyzed: 

```
// lib/esm/renderer-registry-entries.js (before)
"use strict";Object.defineProperty(exports, "__esModule", { value: true });const core_1 = require("@jsonforms/core");
```


**Fix**
Update `tsconfig.esm.json` to emit proper ES6 module syntax:

```
// lib/esm/renderer-registry-entries.js (after)
import { rankWith, isAnyOfControl, ... } from "@jsonforms/core";
export const rendererRegistryEntries = [...]
```


**How to test locally**
Steps I ran to test this locally: 
1. Build the local `jsonforms-antd-renderers` package:  `pnpm build`
1. Link the local package to `mercury-web`:  `pnpm add @great-expectations/jsonforms-antd-renderers@file:/Users/hutchinson/gx/jsonforms-antd-renderers` (from `mercury-web`)
1. Compared the ESM build output directly:
    ```
    # npm 2.2.7 (broken) - uses CommonJS   head -5 node_modules/@great-expectations/jsonforms-antd-renderers/lib/esm/renderer-registry-entries.js      
    # Local fix (correct) - uses ES6 modules   head -5 /path/to/jsonforms-antd-renderers/lib/esm/renderer-registry-entries.js
    ```
1. Built mercury-web for production with pnpm vite build and verified the renderer tester functions (`isAnyOfControl`, `isPrimitiveArrayControl`, etc.) are present in the bundle


**Paths tested** 
These are the following workflows I smoke tested in the UI to verify that the renderers being present didn't break any existing functionality: 

✅ `PrimitiveArrayRenderer`
- Expectation: `expectColumnValuesToBeInSet`
- Field: `value_set` (add/remove string or number values)
- Path: `/organizations/{org}/data-assets/{asset}/expectations` → Create new expectation → "Expect column values to be in set"

`PrimitiveArrayRenderer` <-- **Need to fix [this](https://greatexpectations.atlassian.net/browse/GX-2284) bug first** 
- Expectation: `expectCompoundColumnsToBeUnique`
- Field: `column_list` (add/remove columns)
- Path: `/organizations/{org}/data-assets/{asset}/expectations` → Create new expectation → "Expect compound columns to be unique"

✅ `OneOfRenderer`
- Expectation: `expectColumnValuesToBeInSet`
- Field: `value_set` type selector (switch between Text and Numbers)
- Path: Same as above

✅ `DateTimeRenderer`
- Expectation: `expectColumnValuesToBeBetween`
- Field: `min_value` / `max_value` when column type is date/datetime
- Path: `/organizations/{org}/data-assets/{asset}/expectations` → Create new expectation → "Expect column values to be between" on a date column

✅ `ObjectArrayRenderer`
- Feature: Windowed expectations
- Field: windows (array of Window objects)
- Path: `/organizations/{org}/data-assets/{asset}/expectations` → Create windowed expectation like "Expect table row count to be between" → Add window configuration

I also did additional testing in Storybook: 

✅ `ObjectArrayControl` story:
- Click "Add" to add rows to the array
- Fill in fields in each row
- Click remove to delete rows
- Verify no console errors
- Verify the data in the "Actions" panel updates correctly

✅ `ObjectControl` story:
- Fill in nested object fields
- Verify values persist
- Verify no console errors

✅ `AnyOfControl` story:
- Switch between different type options
- Fill in fields for each type
- Verify switching types works without errors
- Verify data updates correctly

