### PR TITLE
Update publish workflow for trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:


### PR DESCRIPTION
Update the package release workflow to use npm's trusted publisher OIDC instead of npm token
The npm settings for the package are updated via npm.js ([docs](https://docs.npmjs.com/trusted-publishers))