### PR TITLE
fix(TextControl): don't show info icon for empty tooltip

### DIFF
--- a/src/controls/TextControl.test.tsx
+++ b/src/controls/TextControl.test.tsx
@@ -226,4 +226,21 @@ describe("tooltips", () => {
 
     await screen.findByText("You should see this tooltip")
   })
+
+  test("does not show info icon when no tooltip is passed", () => {
+    const uischemaNoTooltip = {
+      type: "VerticalLayout",
+      elements: [
+        {
+          type: "Control",
+          scope: "#/properties/name",
+          label: "Name",
+        },
+      ],
+    }
+    render({ schema, uischema: uischemaNoTooltip })
+    expect(
+      screen.queryByRole("img", { name: /question-circle/i }),
+    ).not.toBeInTheDocument()
+  })
 })

--- a/src/controls/TextControl.tsx
+++ b/src/controls/TextControl.tsx
@@ -40,7 +40,7 @@ export function TextControl({
     "formItemProps" in uischema ? uischema.formItemProps : {}
   const { tooltip: formItemTooltip, ...formItemPropsWOTooltip } =
     formItemProps ?? {}
-  const tooltip = options.tooltip ? options.tooltip : (formItemTooltip ?? "")
+  const tooltip = options.tooltip || formItemTooltip || undefined
 
   const placeholderText = options.placeholderText
   const rules: Rule[] = [


### PR DESCRIPTION
Fixes a bug where tooltips defaulted to an empty string, rather than `undefined`, resulting in an info icon with no tool tip.