### PR TITLE
fix: Inherit form layout from parent and preview layout changes in storybook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ dist-ssr
 *.sln
 *.sw?
 
+# Storybook
+storybook-static
+
 # Built package
 great-expectations-jsonforms-antd-renderers-*.tgz
 

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -9,6 +9,12 @@ const preview: Preview = {
       },
     },
   },
+  argTypes: {
+    layout: {
+      control: "select",
+      options: ["horizontal", "vertical", "inline"],
+    },
+  },
 }
 
 export default preview

--- a/src/common/StorybookAntDJsonForm.tsx
+++ b/src/common/StorybookAntDJsonForm.tsx
@@ -14,10 +14,10 @@ type Props<T> = {
   jsonSchema: T
   rendererRegistryEntries: JsonFormsRendererRegistryEntry[]
   uiSchema?: UISchema<T>
+  layout?: FormProps["layout"]
   uiSchemaRegistryEntries?: JsonFormsUISchemaRegistryEntry[]
   config?: Record<string, unknown>
   onChange: JsonFormsReactProps["onChange"]
-  layout?: FormProps["layout"]
 }
 
 // this component exists to facilitate storybook rendering

--- a/src/hooks/useParentFormLayout.ts
+++ b/src/hooks/useParentFormLayout.ts
@@ -1,0 +1,23 @@
+import { useLayoutEffect, useRef, useState } from "react"
+import type { FormProps } from "antd"
+
+/**
+ * Detects the parent Ant Design Form's layout by inspecting the nearest
+ * ancestor `.ant-form` element's CSS classes. This avoids importing antd's
+ * internal FormContext, which breaks across CJS/ESM module boundaries.
+ */
+export function useParentFormLayout() {
+  const probeRef = useRef<HTMLSpanElement>(null)
+  const [layout, setLayout] = useState<FormProps["layout"]>()
+
+  useLayoutEffect(() => {
+    const el = probeRef.current
+    if (!el) return
+    const formEl = el.closest(".ant-form")
+    if (!formEl) return
+    if (formEl.classList.contains("ant-form-vertical")) setLayout("vertical")
+    else if (formEl.classList.contains("ant-form-inline")) setLayout("inline")
+  }, [])
+
+  return { probeRef, layout }
+}

--- a/src/hooks/useParentFormLayout.ts
+++ b/src/hooks/useParentFormLayout.ts
@@ -9,13 +9,14 @@ import type { FormProps } from "antd"
  * `ant-form-inline`) to determine the layout. When no ancestor form exists or
  * the layout is the default "horizontal", `layout` is `undefined`.
  *
- * We keep the intermediate `<Form>` wrapper (with `component={false}` when
- * nested) rather than conditionally removing it because `Form.List` in the
- * array controls depends on it for correct store structure.
+ * We take this approach for two reasons:
  *
- * We detect layout via the DOM rather than importing antd's internal
- * FormContext because that context is a different object in CJS vs ESM builds,
- * which breaks context sharing when this library is consumed as CJS.
+ * 1. We keep the intermediate `<Form>` wrapper (with `component={false}` when
+ *    nested) rather than conditionally removing it because `Form.List` in the
+ *    array controls depends on it for correct store structure.
+ * 2. We detect layout via the DOM rather than importing antd's internal
+ *    `FormContext` because that context is a different object in CJS vs ESM
+ *    builds, which breaks context sharing when this library is consumed as CJS.
  */
 export function useParentFormLayout() {
   const ref = useRef<HTMLSpanElement>(null)

--- a/src/hooks/useParentFormLayout.ts
+++ b/src/hooks/useParentFormLayout.ts
@@ -17,11 +17,16 @@ export function useParentFormLayout() {
   const ref = useRef<HTMLSpanElement>(null)
   const [layout, setLayout] = useState<FormProps["layout"]>()
 
+  // No dependency array — re-reads the DOM class after every render so the
+  // layout stays in sync when the parent Form's `layout` prop changes.
+  // Safe from infinite loops: setLayout is a no-op when the value is unchanged.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useLayoutEffect(() => {
     const formEl = ref.current?.closest(".ant-form")
     if (formEl?.classList.contains("ant-form-vertical")) setLayout("vertical")
     else if (formEl?.classList.contains("ant-form-inline")) setLayout("inline")
-  }, [])
+    else setLayout(undefined)
+  })
 
   return { ref, layout }
 }

--- a/src/hooks/useParentFormLayout.ts
+++ b/src/hooks/useParentFormLayout.ts
@@ -15,8 +15,9 @@ import type { FormProps } from "antd"
  *    nested) rather than conditionally removing it because `Form.List` in the
  *    array controls depends on it for correct store structure.
  * 2. We detect layout via the DOM rather than importing antd's internal
- *    `FormContext` because that context is a different object in CJS vs ESM
- *    builds, which breaks context sharing when this library is consumed as CJS.
+ *    `FormContext` because it is not part of antd's public API and is a
+ *    different object in CJS vs ESM builds, which breaks context sharing
+ *    when this library is consumed as CJS.
  */
 export function useParentFormLayout() {
   const ref = useRef<HTMLSpanElement>(null)

--- a/src/hooks/useParentFormLayout.ts
+++ b/src/hooks/useParentFormLayout.ts
@@ -2,22 +2,26 @@ import { useLayoutEffect, useRef, useState } from "react"
 import type { FormProps } from "antd"
 
 /**
- * Detects the parent Ant Design Form's layout by inspecting the nearest
- * ancestor `.ant-form` element's CSS classes. This avoids importing antd's
- * internal FormContext, which breaks across CJS/ESM module boundaries.
+ * Returns a ref and the detected layout of the nearest ancestor Ant Design Form.
+ *
+ * Attach `ref` to any element rendered inside the parent Form. The hook reads
+ * the CSS class on the closest `.ant-form` ancestor (`ant-form-vertical`,
+ * `ant-form-inline`) to determine the layout. When no ancestor form exists or
+ * the layout is the default "horizontal", `layout` is `undefined`.
+ *
+ * We detect layout via the DOM rather than importing antd's internal
+ * FormContext because that context is a different object in CJS vs ESM builds,
+ * which breaks context sharing when this library is consumed as CJS.
  */
 export function useParentFormLayout() {
-  const probeRef = useRef<HTMLSpanElement>(null)
+  const ref = useRef<HTMLSpanElement>(null)
   const [layout, setLayout] = useState<FormProps["layout"]>()
 
   useLayoutEffect(() => {
-    const el = probeRef.current
-    if (!el) return
-    const formEl = el.closest(".ant-form")
-    if (!formEl) return
-    if (formEl.classList.contains("ant-form-vertical")) setLayout("vertical")
-    else if (formEl.classList.contains("ant-form-inline")) setLayout("inline")
+    const formEl = ref.current?.closest(".ant-form")
+    if (formEl?.classList.contains("ant-form-vertical")) setLayout("vertical")
+    else if (formEl?.classList.contains("ant-form-inline")) setLayout("inline")
   }, [])
 
-  return { probeRef, layout }
+  return { ref, layout }
 }

--- a/src/hooks/useParentFormLayout.ts
+++ b/src/hooks/useParentFormLayout.ts
@@ -9,6 +9,10 @@ import type { FormProps } from "antd"
  * `ant-form-inline`) to determine the layout. When no ancestor form exists or
  * the layout is the default "horizontal", `layout` is `undefined`.
  *
+ * We keep the intermediate `<Form>` wrapper (with `component={false}` when
+ * nested) rather than conditionally removing it because `Form.List` in the
+ * array controls depends on it for correct store structure.
+ *
  * We detect layout via the DOM rather than importing antd's internal
  * FormContext because that context is a different object in CJS vs ESM builds,
  * which breaks context sharing when this library is consumed as CJS.

--- a/src/layouts/HorizontalLayout.tsx
+++ b/src/layouts/HorizontalLayout.tsx
@@ -39,7 +39,7 @@ export function HorizontalLayout({
       <Row
         justify="space-between"
         gutter={12}
-        align="middle"
+        align="bottom"
         style={{ maxWidth: "100%" }}
       >
         <AntDLayout

--- a/src/layouts/HorizontalLayout.tsx
+++ b/src/layouts/HorizontalLayout.tsx
@@ -53,7 +53,11 @@ export function HorizontalLayout({
     return content
   }
 
-  return <Form data-testid={HORIZONTAL_LAYOUT_FORM_TEST_ID}>{content}</Form>
+  return (
+    <Form data-testid={HORIZONTAL_LAYOUT_FORM_TEST_ID}>
+      {content}
+    </Form>
+  )
 }
 
 export const HorizontalLayoutRenderer =

--- a/src/layouts/HorizontalLayout.tsx
+++ b/src/layouts/HorizontalLayout.tsx
@@ -27,7 +27,7 @@ export function HorizontalLayout({
     visible,
   }
   const form = Form.useFormInstance()
-  const { probeRef, layout } = useParentFormLayout()
+  const { ref, layout } = useParentFormLayout()
 
   if (visible === false) {
     return null
@@ -54,7 +54,7 @@ export function HorizontalLayout({
 
   return (
     <>
-      <span ref={probeRef} style={{ display: "none" }} />
+      <span ref={ref} style={{ display: "none" }} />
       <Form
         data-testid={HORIZONTAL_LAYOUT_FORM_TEST_ID}
         component={form ? false : "form"}

--- a/src/layouts/HorizontalLayout.tsx
+++ b/src/layouts/HorizontalLayout.tsx
@@ -3,9 +3,8 @@ import isEmpty from "lodash.isempty"
 import { AntDLayout, AntDLayoutProps } from "./LayoutRenderer"
 import { HorizontalLayoutUISchema } from "../ui-schema"
 import { Form, Row } from "antd"
-import { FormContext } from "antd/es/form/context"
 import { withJsonFormsLayoutProps } from "@jsonforms/react"
-import { useContext } from "react"
+import { useParentFormLayout } from "../hooks/useParentFormLayout"
 
 export const HORIZONTAL_LAYOUT_FORM_TEST_ID = "horizontal-layout-form"
 
@@ -28,7 +27,7 @@ export function HorizontalLayout({
     visible,
   }
   const form = Form.useFormInstance()
-  const { layout } = useContext(FormContext)
+  const { probeRef, layout } = useParentFormLayout()
 
   if (visible === false) {
     return null
@@ -54,14 +53,17 @@ export function HorizontalLayout({
   )
 
   return (
-    <Form
-      data-testid={HORIZONTAL_LAYOUT_FORM_TEST_ID}
-      component={form ? false : "form"}
-      layout={layout}
-      form={form}
-    >
-      {content}
-    </Form>
+    <>
+      <span ref={probeRef} style={{ display: "none" }} />
+      <Form
+        data-testid={HORIZONTAL_LAYOUT_FORM_TEST_ID}
+        component={form ? false : "form"}
+        layout={layout}
+        form={form}
+      >
+        {content}
+      </Form>
+    </>
   )
 }
 

--- a/src/layouts/HorizontalLayout.tsx
+++ b/src/layouts/HorizontalLayout.tsx
@@ -53,11 +53,7 @@ export function HorizontalLayout({
     return content
   }
 
-  return (
-    <Form data-testid={HORIZONTAL_LAYOUT_FORM_TEST_ID}>
-      {content}
-    </Form>
-  )
+  return <Form data-testid={HORIZONTAL_LAYOUT_FORM_TEST_ID}>{content}</Form>
 }
 
 export const HorizontalLayoutRenderer =

--- a/src/layouts/HorizontalLayout.tsx
+++ b/src/layouts/HorizontalLayout.tsx
@@ -3,7 +3,9 @@ import isEmpty from "lodash.isempty"
 import { AntDLayout, AntDLayoutProps } from "./LayoutRenderer"
 import { HorizontalLayoutUISchema } from "../ui-schema"
 import { Form, Row } from "antd"
+import { FormContext } from "antd/es/form/context"
 import { withJsonFormsLayoutProps } from "@jsonforms/react"
+import { useContext } from "react"
 
 export const HORIZONTAL_LAYOUT_FORM_TEST_ID = "horizontal-layout-form"
 
@@ -26,6 +28,8 @@ export function HorizontalLayout({
     visible,
   }
   const form = Form.useFormInstance()
+  const { layout } = useContext(FormContext)
+
   if (visible === false) {
     return null
   }
@@ -49,11 +53,16 @@ export function HorizontalLayout({
     </>
   )
 
-  if (form) {
-    return content
-  }
-
-  return <Form data-testid={HORIZONTAL_LAYOUT_FORM_TEST_ID}>{content}</Form>
+  return (
+    <Form
+      data-testid={HORIZONTAL_LAYOUT_FORM_TEST_ID}
+      component={form ? false : "form"}
+      layout={layout}
+      form={form}
+    >
+      {content}
+    </Form>
+  )
 }
 
 export const HorizontalLayoutRenderer =

--- a/src/layouts/VerticalLayout.tsx
+++ b/src/layouts/VerticalLayout.tsx
@@ -1,10 +1,9 @@
 import { LayoutProps } from "@jsonforms/core"
 import { AntDLayout, AntDLayoutProps } from "./LayoutRenderer"
 import { Form } from "antd"
-import { FormContext } from "antd/es/form/context"
 import { VerticalLayoutUISchema } from "../ui-schema"
 import { withJsonFormsLayoutProps } from "@jsonforms/react"
-import { useContext } from "react"
+import { useParentFormLayout } from "../hooks/useParentFormLayout"
 
 export const VERTICAL_LAYOUT_FORM_TEST_ID = "vertical-layout-form"
 
@@ -26,22 +25,25 @@ export function VerticalLayout({
     visible,
   }
   const form = Form.useFormInstance()
-  const { layout } = useContext(FormContext)
+  const { probeRef, layout } = useParentFormLayout()
 
   if (visible === false) {
     return null
   }
 
   return (
-    <Form
-      data-testid={VERTICAL_LAYOUT_FORM_TEST_ID}
-      component={form ? false : "form"}
-      layout={layout}
-      scrollToFirstError
-      form={form}
-    >
-      <AntDLayout {...childProps} renderers={renderers} cells={cells} />
-    </Form>
+    <>
+      <span ref={probeRef} style={{ display: "none" }} />
+      <Form
+        data-testid={VERTICAL_LAYOUT_FORM_TEST_ID}
+        component={form ? false : "form"}
+        layout={layout}
+        scrollToFirstError
+        form={form}
+      >
+        <AntDLayout {...childProps} renderers={renderers} cells={cells} />
+      </Form>
+    </>
   )
 }
 

--- a/src/layouts/VerticalLayout.tsx
+++ b/src/layouts/VerticalLayout.tsx
@@ -25,7 +25,7 @@ export function VerticalLayout({
     visible,
   }
   const form = Form.useFormInstance()
-  const { probeRef, layout } = useParentFormLayout()
+  const { ref, layout } = useParentFormLayout()
 
   if (visible === false) {
     return null
@@ -33,7 +33,7 @@ export function VerticalLayout({
 
   return (
     <>
-      <span ref={probeRef} style={{ display: "none" }} />
+      <span ref={ref} style={{ display: "none" }} />
       <Form
         data-testid={VERTICAL_LAYOUT_FORM_TEST_ID}
         component={form ? false : "form"}

--- a/src/layouts/VerticalLayout.tsx
+++ b/src/layouts/VerticalLayout.tsx
@@ -1,8 +1,10 @@
 import { LayoutProps } from "@jsonforms/core"
 import { AntDLayout, AntDLayoutProps } from "./LayoutRenderer"
 import { Form } from "antd"
+import { FormContext } from "antd/es/form/context"
 import { VerticalLayoutUISchema } from "../ui-schema"
 import { withJsonFormsLayoutProps } from "@jsonforms/react"
+import { useContext } from "react"
 
 export const VERTICAL_LAYOUT_FORM_TEST_ID = "vertical-layout-form"
 
@@ -24,22 +26,21 @@ export function VerticalLayout({
     visible,
   }
   const form = Form.useFormInstance()
+  const { layout } = useContext(FormContext)
 
   if (visible === false) {
     return null
   }
 
-  const content = (
-    <AntDLayout {...childProps} renderers={renderers} cells={cells} />
-  )
-
-  if (form) {
-    return content
-  }
-
   return (
-    <Form data-testid={VERTICAL_LAYOUT_FORM_TEST_ID} scrollToFirstError>
-      {content}
+    <Form
+      data-testid={VERTICAL_LAYOUT_FORM_TEST_ID}
+      component={form ? false : "form"}
+      layout={layout}
+      scrollToFirstError
+      form={form}
+    >
+      <AntDLayout {...childProps} renderers={renderers} cells={cells} />
     </Form>
   )
 }

--- a/src/layouts/VerticalLayout.tsx
+++ b/src/layouts/VerticalLayout.tsx
@@ -38,10 +38,7 @@ export function VerticalLayout({
   }
 
   return (
-    <Form
-      data-testid={VERTICAL_LAYOUT_FORM_TEST_ID}
-      scrollToFirstError
-    >
+    <Form data-testid={VERTICAL_LAYOUT_FORM_TEST_ID} scrollToFirstError>
       {content}
     </Form>
   )

--- a/src/layouts/VerticalLayout.tsx
+++ b/src/layouts/VerticalLayout.tsx
@@ -29,14 +29,20 @@ export function VerticalLayout({
     return null
   }
 
+  const content = (
+    <AntDLayout {...childProps} renderers={renderers} cells={cells} />
+  )
+
+  if (form) {
+    return content
+  }
+
   return (
     <Form
       data-testid={VERTICAL_LAYOUT_FORM_TEST_ID}
-      component={form ? false : "form"}
       scrollToFirstError
-      form={form}
     >
-      <AntDLayout {...childProps} renderers={renderers} cells={cells} />
+      {content}
     </Form>
   )
 }

--- a/src/stories/controls/AnyOfControl.stories.tsx
+++ b/src/stories/controls/AnyOfControl.stories.tsx
@@ -41,6 +41,7 @@ const meta: Meta<typeof StorybookAntDJsonForm<typeof splitterAnyOfJsonSchema>> =
         control: "object",
         description: "this is a minimal anyOf combinator schema",
       },
+      layout: {},
       uiSchemaRegistryEntries: { table: { disable: true } },
       data: { table: { disable: true } },
       config: { control: "object" },

--- a/src/stories/controls/AnyOfControl.stories.tsx
+++ b/src/stories/controls/AnyOfControl.stories.tsx
@@ -41,6 +41,7 @@ const meta: Meta<typeof StorybookAntDJsonForm<typeof splitterAnyOfJsonSchema>> =
         control: "object",
         description: "this is a minimal anyOf combinator schema",
       },
+      uiSchema: { control: "object" },
       layout: {},
       uiSchemaRegistryEntries: { table: { disable: true } },
       data: { table: { disable: true } },

--- a/src/stories/controls/BooleanControl.stories.tsx
+++ b/src/stories/controls/BooleanControl.stories.tsx
@@ -41,6 +41,7 @@ const meta: Meta<typeof StorybookAntDJsonForm> = {
     jsonSchema: {
       control: "object",
     },
+    layout: {},
     data: { table: { disable: true } },
     config: { control: "object" },
     onChange: { table: { disable: true, action: "on-change" } },

--- a/src/stories/controls/BooleanControl.stories.tsx
+++ b/src/stories/controls/BooleanControl.stories.tsx
@@ -41,6 +41,7 @@ const meta: Meta<typeof StorybookAntDJsonForm> = {
     jsonSchema: {
       control: "object",
     },
+    uiSchema: { control: "object" },
     layout: {},
     data: { table: { disable: true } },
     config: { control: "object" },

--- a/src/stories/controls/DateTimeControl.stories.tsx
+++ b/src/stories/controls/DateTimeControl.stories.tsx
@@ -18,8 +18,13 @@ const meta: Meta<typeof StorybookAntDJsonForm> = {
     uiSchema: dateTimeUISchema,
   },
   argTypes: {
+    rendererRegistryEntries: { table: { disable: true } },
     uiSchema: { control: "object" },
     layout: {},
+    uiSchemaRegistryEntries: { table: { disable: true } },
+    data: { table: { disable: true } },
+    config: { control: "object" },
+    onChange: { table: { disable: true, action: "on-change" } },
   },
 }
 

--- a/src/stories/controls/DateTimeControl.stories.tsx
+++ b/src/stories/controls/DateTimeControl.stories.tsx
@@ -17,7 +17,9 @@ const meta: Meta<typeof StorybookAntDJsonForm> = {
     jsonSchema: dateTimeSchema,
     uiSchema: dateTimeUISchema,
   },
-  argTypes: {},
+  argTypes: {
+    layout: {},
+  },
 }
 
 export default meta

--- a/src/stories/controls/DateTimeControl.stories.tsx
+++ b/src/stories/controls/DateTimeControl.stories.tsx
@@ -18,6 +18,7 @@ const meta: Meta<typeof StorybookAntDJsonForm> = {
     uiSchema: dateTimeUISchema,
   },
   argTypes: {
+    uiSchema: { control: "object" },
     layout: {},
   },
 }

--- a/src/stories/controls/EnumControl.stories.tsx
+++ b/src/stories/controls/EnumControl.stories.tsx
@@ -23,6 +23,7 @@ const meta: Meta<typeof StorybookAntDJsonForm> = {
     uiSchema: {
       control: "object",
     },
+    layout: {},
   },
 }
 

--- a/src/stories/controls/EnumControl.stories.tsx
+++ b/src/stories/controls/EnumControl.stories.tsx
@@ -20,10 +20,13 @@ const meta: Meta<typeof StorybookAntDJsonForm> = {
     uiSchema: enumProfessionUISchema,
   },
   argTypes: {
-    uiSchema: {
-      control: "object",
-    },
+    rendererRegistryEntries: { table: { disable: true } },
+    uiSchema: { control: "object" },
     layout: {},
+    uiSchemaRegistryEntries: { table: { disable: true } },
+    data: { table: { disable: true } },
+    config: { control: "object" },
+    onChange: { table: { disable: true, action: "on-change" } },
   },
 }
 

--- a/src/stories/controls/NumericControl.stories.tsx
+++ b/src/stories/controls/NumericControl.stories.tsx
@@ -22,10 +22,13 @@ const meta: Meta<typeof StorybookAntDJsonForm> = {
     uiSchema: numericVerticalUISchema,
   },
   argTypes: {
-    uiSchema: {
-      control: "object",
-    },
+    rendererRegistryEntries: { table: { disable: true } },
+    uiSchema: { control: "object" },
     layout: {},
+    uiSchemaRegistryEntries: { table: { disable: true } },
+    data: { table: { disable: true } },
+    config: { control: "object" },
+    onChange: { table: { disable: true, action: "on-change" } },
   },
 }
 

--- a/src/stories/controls/NumericControl.stories.tsx
+++ b/src/stories/controls/NumericControl.stories.tsx
@@ -25,6 +25,7 @@ const meta: Meta<typeof StorybookAntDJsonForm> = {
     uiSchema: {
       control: "object",
     },
+    layout: {},
   },
 }
 

--- a/src/stories/controls/NumericSliderControl.stories.tsx
+++ b/src/stories/controls/NumericSliderControl.stories.tsx
@@ -22,10 +22,13 @@ const meta: Meta<typeof StorybookAntDJsonForm> = {
     uiSchema: numericSliderVerticalUISchema,
   },
   argTypes: {
-    uiSchema: {
-      control: "object",
-    },
+    rendererRegistryEntries: { table: { disable: true } },
+    uiSchema: { control: "object" },
     layout: {},
+    uiSchemaRegistryEntries: { table: { disable: true } },
+    data: { table: { disable: true } },
+    config: { control: "object" },
+    onChange: { table: { disable: true, action: "on-change" } },
   },
 }
 

--- a/src/stories/controls/NumericSliderControl.stories.tsx
+++ b/src/stories/controls/NumericSliderControl.stories.tsx
@@ -25,6 +25,7 @@ const meta: Meta<typeof StorybookAntDJsonForm> = {
     uiSchema: {
       control: "object",
     },
+    layout: {},
   },
 }
 

--- a/src/stories/controls/ObjectArrayControl.stories.tsx
+++ b/src/stories/controls/ObjectArrayControl.stories.tsx
@@ -25,6 +25,7 @@ const meta: Meta<typeof StorybookAntDJsonForm> = {
     jsonSchema: {
       control: "object",
     },
+    uiSchema: { control: "object" },
     layout: {},
     uiSchemaRegistryEntries: { table: { disable: true } },
     data: { table: { disable: true } },

--- a/src/stories/controls/ObjectArrayControl.stories.tsx
+++ b/src/stories/controls/ObjectArrayControl.stories.tsx
@@ -25,6 +25,7 @@ const meta: Meta<typeof StorybookAntDJsonForm> = {
     jsonSchema: {
       control: "object",
     },
+    layout: {},
     uiSchemaRegistryEntries: { table: { disable: true } },
     data: { table: { disable: true } },
     config: { control: "object" },

--- a/src/stories/controls/ObjectControl.stories.tsx
+++ b/src/stories/controls/ObjectControl.stories.tsx
@@ -24,6 +24,7 @@ const meta: Meta<typeof StorybookAntDJsonForm> = {
     jsonSchema: {
       control: "object",
     },
+    uiSchema: { control: "object" },
     layout: {},
     uiSchemaRegistryEntries: { table: { disable: true } },
     data: { table: { disable: true } },

--- a/src/stories/controls/ObjectControl.stories.tsx
+++ b/src/stories/controls/ObjectControl.stories.tsx
@@ -24,6 +24,7 @@ const meta: Meta<typeof StorybookAntDJsonForm> = {
     jsonSchema: {
       control: "object",
     },
+    layout: {},
     uiSchemaRegistryEntries: { table: { disable: true } },
     data: { table: { disable: true } },
     config: { control: "object" },

--- a/src/stories/controls/OneOfControl.stories.tsx
+++ b/src/stories/controls/OneOfControl.stories.tsx
@@ -70,6 +70,7 @@ const meta: Meta<typeof StorybookAntDJsonForm> = {
       control: "object",
       description: "this is a minimal oneOf combinator schema",
     },
+    layout: {},
     uiSchemaRegistryEntries: { table: { disable: true } },
     data: { table: { disable: true } },
     config: { control: "object" },

--- a/src/stories/controls/OneOfControl.stories.tsx
+++ b/src/stories/controls/OneOfControl.stories.tsx
@@ -70,6 +70,7 @@ const meta: Meta<typeof StorybookAntDJsonForm> = {
       control: "object",
       description: "this is a minimal oneOf combinator schema",
     },
+    uiSchema: { control: "object" },
     layout: {},
     uiSchemaRegistryEntries: { table: { disable: true } },
     data: { table: { disable: true } },

--- a/src/stories/controls/PrimitiveArrayControl.stories.tsx
+++ b/src/stories/controls/PrimitiveArrayControl.stories.tsx
@@ -22,6 +22,7 @@ const meta: Meta<typeof StorybookAntDJsonForm> = {
     jsonSchema: {
       control: "object",
     },
+    uiSchema: { control: "object" },
     layout: {},
     uiSchemaRegistryEntries: { table: { disable: true } },
     data: { table: { disable: true } },

--- a/src/stories/controls/PrimitiveArrayControl.stories.tsx
+++ b/src/stories/controls/PrimitiveArrayControl.stories.tsx
@@ -19,6 +19,7 @@ const meta: Meta<typeof StorybookAntDJsonForm> = {
   },
   // More on argTypes: https://storybook.js.org/docs/api/argtypes
   argTypes: {
+    rendererRegistryEntries: { table: { disable: true } },
     jsonSchema: {
       control: "object",
     },

--- a/src/stories/controls/PrimitiveArrayControl.stories.tsx
+++ b/src/stories/controls/PrimitiveArrayControl.stories.tsx
@@ -22,6 +22,7 @@ const meta: Meta<typeof StorybookAntDJsonForm> = {
     jsonSchema: {
       control: "object",
     },
+    layout: {},
     uiSchemaRegistryEntries: { table: { disable: true } },
     data: { table: { disable: true } },
     config: { control: "object" },

--- a/src/stories/controls/TextControl.stories.tsx
+++ b/src/stories/controls/TextControl.stories.tsx
@@ -40,6 +40,7 @@ const meta: Meta<typeof StorybookAntDJsonForm> = {
       control: "object",
       description: "this is a simple schema with one property (name)",
     },
+    uiSchema: { control: "object" },
     layout: {},
     uiSchemaRegistryEntries: { table: { disable: true } },
     data: { table: { disable: true } },

--- a/src/stories/controls/TextControl.stories.tsx
+++ b/src/stories/controls/TextControl.stories.tsx
@@ -40,6 +40,7 @@ const meta: Meta<typeof StorybookAntDJsonForm> = {
       control: "object",
       description: "this is a simple schema with one property (name)",
     },
+    layout: {},
     uiSchemaRegistryEntries: { table: { disable: true } },
     data: { table: { disable: true } },
     config: { control: "object" },

--- a/src/stories/layouts/AlertLayout.stories.tsx
+++ b/src/stories/layouts/AlertLayout.stories.tsx
@@ -33,6 +33,7 @@ const meta: Meta<typeof StorybookAntDJsonForm> = {
     jsonSchema: {
       control: "object",
     },
+    uiSchema: { control: "object" },
     layout: {},
     data: { table: { disable: true } },
     config: { control: "object" },

--- a/src/stories/layouts/AlertLayout.stories.tsx
+++ b/src/stories/layouts/AlertLayout.stories.tsx
@@ -33,6 +33,7 @@ const meta: Meta<typeof StorybookAntDJsonForm> = {
     jsonSchema: {
       control: "object",
     },
+    layout: {},
     data: { table: { disable: true } },
     config: { control: "object" },
     onChange: { table: { disable: true, action: "on-change" } },

--- a/src/stories/layouts/GroupLayout.stories.tsx
+++ b/src/stories/layouts/GroupLayout.stories.tsx
@@ -38,6 +38,7 @@ const meta: Meta<typeof StorybookAntDJsonForm> = {
     jsonSchema: {
       control: "object",
     },
+    uiSchema: { control: "object" },
     layout: {},
     data: { table: { disable: true } },
     config: { control: "object" },

--- a/src/stories/layouts/GroupLayout.stories.tsx
+++ b/src/stories/layouts/GroupLayout.stories.tsx
@@ -38,6 +38,7 @@ const meta: Meta<typeof StorybookAntDJsonForm> = {
     jsonSchema: {
       control: "object",
     },
+    layout: {},
     data: { table: { disable: true } },
     config: { control: "object" },
     onChange: { table: { disable: true, action: "on-change" } },

--- a/src/stories/layouts/HorizontalLayout.stories.tsx
+++ b/src/stories/layouts/HorizontalLayout.stories.tsx
@@ -18,6 +18,9 @@ const meta: Meta<typeof StorybookAntDJsonForm> = {
   title: "Layout/Horizontal",
   component: StorybookAntDJsonForm,
   tags: ["autodocs"],
+  argTypes: {
+    layout: {},
+  },
 }
 
 export default meta

--- a/src/stories/layouts/HorizontalLayout.stories.tsx
+++ b/src/stories/layouts/HorizontalLayout.stories.tsx
@@ -19,8 +19,13 @@ const meta: Meta<typeof StorybookAntDJsonForm> = {
   component: StorybookAntDJsonForm,
   tags: ["autodocs"],
   argTypes: {
+    rendererRegistryEntries: { table: { disable: true } },
     uiSchema: { control: "object" },
     layout: {},
+    uiSchemaRegistryEntries: { table: { disable: true } },
+    data: { table: { disable: true } },
+    config: { control: "object" },
+    onChange: { table: { disable: true, action: "on-change" } },
   },
 }
 

--- a/src/stories/layouts/HorizontalLayout.stories.tsx
+++ b/src/stories/layouts/HorizontalLayout.stories.tsx
@@ -19,6 +19,7 @@ const meta: Meta<typeof StorybookAntDJsonForm> = {
   component: StorybookAntDJsonForm,
   tags: ["autodocs"],
   argTypes: {
+    uiSchema: { control: "object" },
     layout: {},
   },
 }

--- a/src/stories/layouts/VerticalLayout.stories.tsx
+++ b/src/stories/layouts/VerticalLayout.stories.tsx
@@ -15,8 +15,13 @@ const meta: Meta<typeof StorybookAntDJsonForm> = {
   component: StorybookAntDJsonForm,
   tags: ["autodocs"],
   argTypes: {
+    rendererRegistryEntries: { table: { disable: true } },
     uiSchema: { control: "object" },
     layout: {},
+    uiSchemaRegistryEntries: { table: { disable: true } },
+    data: { table: { disable: true } },
+    config: { control: "object" },
+    onChange: { table: { disable: true, action: "on-change" } },
   },
 }
 

--- a/src/stories/layouts/VerticalLayout.stories.tsx
+++ b/src/stories/layouts/VerticalLayout.stories.tsx
@@ -15,6 +15,7 @@ const meta: Meta<typeof StorybookAntDJsonForm> = {
   component: StorybookAntDJsonForm,
   tags: ["autodocs"],
   argTypes: {
+    uiSchema: { control: "object" },
     layout: {},
   },
 }

--- a/src/stories/layouts/VerticalLayout.stories.tsx
+++ b/src/stories/layouts/VerticalLayout.stories.tsx
@@ -14,6 +14,9 @@ const meta: Meta<typeof StorybookAntDJsonForm> = {
   title: "Layout/Vertical",
   component: StorybookAntDJsonForm,
   tags: ["autodocs"],
+  argTypes: {
+    layout: {},
+  },
 }
 
 export default meta


### PR DESCRIPTION
## Why

`VerticalLayout` and `HorizontalLayout` each render their own `<Form>` wrapper, which creates a new Ant Design form context. Without an explicit `layout` prop, this inner `<Form>` defaults to `"horizontal"`, silently overriding whatever layout the consumer's parent `<Form>` specifies. So a consumer wrapping jsonforms in `<Form layout="vertical">` would have their layout ignored.

The inner `<Form>` wrapper cannot simply be removed when a parent form exists because `Form.List` (used by array controls) depends on it for correct store structure and field management.

An earlier iteration imported `FormContext` from `antd/es/form/context` to read the parent layout, but this broke in consuming apps due to CJS/ESM module identity mismatch — the library's CJS build resolved a different context instance than the one the consumer's `<Form>` provides.

## What

- **`useParentFormLayout` hook** (new): Detects the parent form's layout by reading CSS classes (`ant-form-vertical`, `ant-form-inline`) on the nearest ancestor `.ant-form` element. This avoids importing antd's internal `FormContext` and works reliably across CJS/ESM module boundaries.
- **`VerticalLayout` / `HorizontalLayout`**: Use `useParentFormLayout` to read the parent form's layout and forward it to the inner `<Form>`. The `<Form>` wrapper is preserved (required by `Form.List` in array controls) with `component={false}` when nested, so no extra DOM element is emitted.
- **Storybook**: Add a global `layout` arg (horizontal / vertical / inline) so all stories can preview label orientations from the controls panel.
- **`.gitignore`**: Add `storybook-static/`.