### PR TITLE
fix(deps): bump handlebars 4.7.8 → 4.7.9 (CVE-2026-33937)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2270,8 +2270,8 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
-  handlebars@4.7.8:
-    resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
+  handlebars@4.7.9:
+    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
     engines: {node: '>=0.4.7'}
     hasBin: true
 
@@ -6228,7 +6228,7 @@ snapshots:
   conventional-changelog-writer@7.0.1:
     dependencies:
       conventional-commits-filter: 4.0.0
-      handlebars: 4.7.8
+      handlebars: 4.7.9
       json-stringify-safe: 5.0.1
       meow: 12.1.1
       semver: 7.7.3
@@ -6976,7 +6976,7 @@ snapshots:
 
   graphemer@1.4.0: {}
 
-  handlebars@4.7.8:
+  handlebars@4.7.9:
     dependencies:
       minimist: 1.2.8
       neo-async: 2.6.2


### PR DESCRIPTION
## Security Fix

Bumps \`handlebars\` from **4.7.8 → 4.7.9** to resolve a critical security vulnerability.

### Vulnerability

**CVE-2026-33937** — Handlebars.js JavaScript Injection via AST Type Confusion
- Severity: **Critical (CVSS 9.8)**
- Advisory: https://nvd.nist.gov/vuln/detail/CVE-2026-33937
- Affected: \`handlebars >= 4.0.0, <= 4.7.8\`
- Fixed in: \`handlebars >= 4.7.9\`

### What changed

`handlebars` is a transitive dependency pulled in by `semantic-release` → `conventional-changelog-writer@7.0.1`, which specifies `handlebars: "^4.7.7"`. That range already covers 4.7.9 - the lockfile was stale at 4.7.8. Only `pnpm-lock.yaml` needed updating, no `package.json` changes are required.

Verified with `pnpm why handlebars`:
```
└── handlebars 4.7.9
```