### PR TITLE
fix(deps): bump vite 6.4.1→6.4.2 (CVE-2026-39363)

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "semantic-release": "^23.1.1",
     "storybook": "^8.6.17",
     "typescript": "^5.6.2",
-    "vite": "^6.4.1",
+    "vite": "^6.4.2",
     "vitest": "^4.0.15"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,7 +71,7 @@ importers:
         version: 8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@3.5.3)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.18(prettier@3.5.3))(typescript@5.9.3)
       '@storybook/react-vite':
         specifier: ^8.6.17
-        version: 8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@3.5.3)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.1)(storybook@8.6.18(prettier@3.5.3))(typescript@5.9.3)(vite@6.4.1)
+        version: 8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@3.5.3)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.1)(storybook@8.6.18(prettier@3.5.3))(typescript@5.9.3)(vite@6.4.2)
       '@storybook/test':
         specifier: ^8.6.17
         version: 8.6.18(storybook@8.6.18(prettier@3.5.3))
@@ -110,7 +110,7 @@ importers:
         version: 6.21.0(eslint@8.57.1)(typescript@5.9.3)
       '@vitejs/plugin-react':
         specifier: ^4.3.1
-        version: 4.7.0(vite@6.4.1)
+        version: 4.7.0(vite@6.4.2)
       '@vitest/coverage-istanbul':
         specifier: 4.0.15
         version: 4.0.15(vitest@4.0.15)
@@ -163,8 +163,8 @@ importers:
         specifier: ^5.6.2
         version: 5.9.3
       vite:
-        specifier: ^6.4.1
-        version: 6.4.1
+        specifier: ^6.4.2
+        version: 6.4.2
       vitest:
         specifier: ^4.0.15
         version: 4.0.15(@vitest/ui@1.6.1)(jsdom@24.1.3)
@@ -4262,8 +4262,8 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  vite@6.4.1:
-    resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
+  vite@6.4.2:
+    resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -4823,12 +4823,12 @@ snapshots:
     dependencies:
       '@sinclair/typebox': 0.27.8
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.5.0(typescript@5.9.3)(vite@6.4.1)':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.5.0(typescript@5.9.3)(vite@6.4.2)':
     dependencies:
       glob: 10.5.0
       magic-string: 0.27.0
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
-      vite: 6.4.1
+      vite: 6.4.2
     optionalDependencies:
       typescript: 5.9.3
 
@@ -5316,13 +5316,13 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/builder-vite@8.6.18(storybook@8.6.18(prettier@3.5.3))(vite@6.4.1)':
+  '@storybook/builder-vite@8.6.18(storybook@8.6.18(prettier@3.5.3))(vite@6.4.2)':
     dependencies:
       '@storybook/csf-plugin': 8.6.18(storybook@8.6.18(prettier@3.5.3))
       browser-assert: 1.2.1
       storybook: 8.6.18(prettier@3.5.3)
       ts-dedent: 2.2.0
-      vite: 6.4.1
+      vite: 6.4.2
 
   '@storybook/components@8.6.18(storybook@8.6.18(prettier@3.5.3))':
     dependencies:
@@ -5385,11 +5385,11 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       storybook: 8.6.18(prettier@3.5.3)
 
-  '@storybook/react-vite@8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@3.5.3)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.1)(storybook@8.6.18(prettier@3.5.3))(typescript@5.9.3)(vite@6.4.1)':
+  '@storybook/react-vite@8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@3.5.3)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.1)(storybook@8.6.18(prettier@3.5.3))(typescript@5.9.3)(vite@6.4.2)':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.5.0(typescript@5.9.3)(vite@6.4.1)
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.5.0(typescript@5.9.3)(vite@6.4.2)
       '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
-      '@storybook/builder-vite': 8.6.18(storybook@8.6.18(prettier@3.5.3))(vite@6.4.1)
+      '@storybook/builder-vite': 8.6.18(storybook@8.6.18(prettier@3.5.3))(vite@6.4.2)
       '@storybook/react': 8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@3.5.3)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.18(prettier@3.5.3))(typescript@5.9.3)
       find-up: 5.0.0
       magic-string: 0.30.21
@@ -5399,7 +5399,7 @@ snapshots:
       resolve: 1.22.11
       storybook: 8.6.18(prettier@3.5.3)
       tsconfig-paths: 4.2.0
-      vite: 6.4.1
+      vite: 6.4.2
     optionalDependencies:
       '@storybook/test': 8.6.18(storybook@8.6.18(prettier@3.5.3))
     transitivePeerDependencies:
@@ -5763,7 +5763,7 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.1)':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.2)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
@@ -5771,7 +5771,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.1
+      vite: 6.4.2
     transitivePeerDependencies:
       - supports-color
 
@@ -5808,13 +5808,13 @@ snapshots:
       chai: 6.2.1
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.15(vite@6.4.1)':
+  '@vitest/mocker@4.0.15(vite@6.4.2)':
     dependencies:
       '@vitest/spy': 4.0.15
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.1
+      vite: 6.4.2
 
   '@vitest/pretty-format@2.0.5':
     dependencies:
@@ -9263,7 +9263,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@6.4.1:
+  vite@6.4.2:
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -9277,7 +9277,7 @@ snapshots:
   vitest@4.0.15(@vitest/ui@1.6.1)(jsdom@24.1.3):
     dependencies:
       '@vitest/expect': 4.0.15
-      '@vitest/mocker': 4.0.15(vite@6.4.1)
+      '@vitest/mocker': 4.0.15(vite@6.4.2)
       '@vitest/pretty-format': 4.0.15
       '@vitest/runner': 4.0.15
       '@vitest/snapshot': 4.0.15
@@ -9294,7 +9294,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 6.4.1
+      vite: 6.4.2
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@vitest/ui': 1.6.1(vitest@4.0.15)


### PR DESCRIPTION
Bumps `vite` from **6.4.1 → 6.4.2** to resolve CVE-2026-39363 (High): affects `vite >= 6.0.0, <= 6.4.1`.

Both `package.json` (specifier updated to `^6.4.2`) and `pnpm-lock.yaml` are updated to stay consistent.